### PR TITLE
Set the default_auto_field for the app

### DIFF
--- a/feeds/apps.py
+++ b/feeds/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class FeedsConfig(AppConfig):
     name = 'feeds'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
If a project has set a `DEFAULT_AUTO_FIELD` setting ([docs](https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field)) then running migrations for the project generates a new migration for django-feed-reader.

I believe apps need to specify a `default_auto_field` so this doesn't happen https://stackoverflow.com/questions/67006488/migrating-models-of-dependencies-when-changing-default-auto-field/67007098#67007098

For #8