### PR TITLE
Handle feed items with updated time but no published time

### DIFF
--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -524,10 +524,12 @@ def parse_feed_xml(source_feed, feed_content, output):
 
                 try:
                     p.created  = datetime.datetime.fromtimestamp(time.mktime(e.published_parsed)).replace(tzinfo=timezone.utc)
-
                 except Exception as ex2:
-                    output.write("CREATED ERROR:" + str(ex2))     
-                    p.created  = timezone.now()
+                    try:
+                        p.created  = datetime.datetime.fromtimestamp(time.mktime(e.updated_parsed)).replace(tzinfo=timezone.utc)
+                    except Exception as ex3:
+                        output.write("CREATED ERROR:" + str(ex3))
+                        p.created  = timezone.now()
 
 
                 p.source = source_feed


### PR DESCRIPTION
If a feed item has `<updated>` but no `<published>` time, we use that for the `Post.created` datetime, instead of using "now".

**NOTE:** I was going to add a test for this but when trying to run the existing tests I got `ModuleNotFoundError: No module named 'mock'`, so I'm wondering if these tests are ever used these days?

**NOTE 2:**  Once I'd changed the import to work, I got errors like `AttributeError: module 'feedparser' has no attribute '_sanitizeHTML'`. It does look like there's no such method. A quick glance suggests [it sanitizes fields by default](https://feedparser.readthedocs.io/en/latest/html-sanitization.html)? I'm not sure what that attempt at calling the method is doing.

For #18