### PR TITLE
fix: bound feed history pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ If `FEEDS_SERVER` is not set, the library will derive a default from `ALLOWED_HO
   - Useful when you want access to custom or uncommon feed attributes.
   - Increases database usage.
 
+- `FEEDS_MAX_PAGINATION_PAGES` (default: `20`)
+  - Maximum number of additional `rel="next"` pages fetched when backfilling a new XML/Atom source.
+
+- `FEEDS_MAX_PAGINATION_ENTRIES` (default: `2000`)
+  - Maximum total entries imported during the initial XML/Atom history backfill.
+  - Both pagination limits must be positive integers; invalid values use their defaults.
+
 - `FEEDS_DRIPFEED_KEY` (default: unset)
   - If present, Cloudflare-blocked feeds can be retried via [Dripfeed](https://dripfeed.app).
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 
 ### 2.0.1
+- Fix: Bound first-import XML/Atom pagination, detect repeated page URLs, and stop cleanly on failed pagination responses
 - Fix: `get_unread_subscription_list_for_user` no longer returns read-only folder subscriptions as unread
 - Fix: Paginated feed import (`rel="next"`) when backfilling history for a new source
 - Fix: Numerous polling and parsing bugs (HTTP errors and timeouts, 304 handling and stale etag clearing, relative redirects, JSON feed expiry, empty or invalid bodies, entries without `enclosures`, incorrect `update_fields`, `Source.get_unread_posts`, `Post.title_url_encoded`, timezone-aware `due_poll`, and related issues)

--- a/docs/modules/overview.rst
+++ b/docs/modules/overview.rst
@@ -249,6 +249,12 @@ Optional
 ``FEEDS_SAVE_JSON`` (default ``False``)
   Store raw parsed feed data in the ``json`` fields on ``Source`` and ``Post``. Useful if you need access to custom feed attributes, but it increases database usage.
 
+``FEEDS_MAX_PAGINATION_PAGES`` (default ``20``)
+  Maximum number of additional ``rel="next"`` pages fetched when backfilling a new XML/Atom source.
+
+``FEEDS_MAX_PAGINATION_ENTRIES`` (default ``2000``)
+  Maximum total entries imported during the initial XML/Atom history backfill. Both pagination limits must be positive integers; invalid values use their defaults.
+
 ``FEEDS_DRIPFEED_KEY`` (default unset)
   If present, Cloudflare-blocked feeds can be retried via `Dripfeed <https://dripfeed.app>`_.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -180,8 +180,10 @@ Evidence: `feeds/utils.py`; `feeds/url_safety.py`;
   `align`, `valign`, `hspace`, `width`, and `height` attributes shall additionally
   be removed from the sanitizer's acceptable attributes.
 - **PARSE-011** — On the first successful XML/Atom import, `rel="next"` links shall
-  be followed to backfill available history. The lack of termination safeguards is
-  recorded under assumption A-001 and gap GAP-001.
+  be followed to backfill available history, up to 20 additional pages and 2,000
+  total entries by default. Repeated or unsafe page URLs, failed responses, empty
+  responses, and invalid feeds shall stop the backfill while preserving imported
+  posts.
 - **PARSE-012** — When raw JSON storage is enabled, parsed source and entry data
   shall be stored in their JSON fields, excluding the duplicated entries/items list
   from the source payload.
@@ -270,6 +272,9 @@ Evidence: `feeds/utils.py`; `feeds/tests/test_http.py`;
   `FEEDS_KEEP_OLD_ENCLOSURES`, `FEEDS_SAVE_JSON`, `FEEDS_DRIPFEED_KEY`, and
   `FEEDS_CLOUDFLARE_WORKER`. Their relationship to unprefixed names in project
   guidance is subject to assumption A-005.
+- **CFG-007** — `FEEDS_MAX_PAGINATION_PAGES` and
+  `FEEDS_MAX_PAGINATION_ENTRIES` shall default to 20 and 2,000 respectively.
+  Invalid or non-positive values shall use those defaults.
 
 Evidence: `feeds/__init__.py`; module-level settings in `feeds/utils.py` and
 `feeds/utils_internal.py`; `feeds/management/commands/refreshfeeds.py`;
@@ -284,8 +289,8 @@ Evidence: `feeds/__init__.py`; module-level settings in `feeds/utils.py` and
   represented by package metadata; the current classifier list includes Django
   3.2, 4.2, 5.0, and 5.1.
 - **NFR-001** — Polling shall bound direct HTTP waits with a 20-second request
-  timeout. First-import pagination currently weakens this bound at the workflow
-  level as recorded in GAP-001.
+  timeout and first-import history backfill with configurable page and entry
+  limits.
 - **NFR-002** — Scheduled polling, subscription tree loading, post lookup, and
   enclosure synchronization shall use the existing indexes and batched operations
   intended to avoid per-row query growth in common workflows.
@@ -297,9 +302,6 @@ Evidence: `AGENTS.md`; `setup.py`; `feeds/models.py`;
 
 ## 10. Suspected defects, contradictions, and coverage gaps
 
-- **GAP-001 — Unbounded pagination:** first-import Atom pagination has no page cap,
-  repeated-URL detection, or entry cap. GitHub issue #43 reports an effectively
-  indefinite import producing thousands of posts.
 - **GAP-002 — `last_polled` persistence:** `read_feed` assigns `last_polled`, but the
   final partial save omits that field, so the assignment is not persisted by the
   observed path.
@@ -327,21 +329,6 @@ These entries describe evidence and are not target-state requirements.
 
 The specification was approved without resolving the following assumptions. They
 remain provisional and must not be treated as confirmed target-state decisions.
-
-### A-001 — Unbounded history backfill
-
-Provisional interpretation: exhaustive first-import pagination is intended, but
-the absence of termination safeguards is a defect.
-
-Evidence: recursive/iterative `rel="next"` handling in `parse_feed_xml`, pagination
-tests, and open GitHub issue #43.
-
-Confidence: high.
-
-Impact if wrong: pagination requirements, resource limits, imported history, and
-operator recovery behavior.
-
-Question: Should pagination be bounded and protected by repeated-URL detection?
 
 ### A-002 — Automatic source disabling
 

--- a/feeds/tests/test_xml_feeds.py
+++ b/feeds/tests/test_xml_feeds.py
@@ -3,6 +3,7 @@ from importlib import reload
 
 import requests_mock
 from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 
 from feeds import utils, utils_internal
@@ -11,6 +12,32 @@ from feeds.utils import read_feed
 from feeds.utils_internal import hash_body
 
 from .base import BASE_URL, TEST_FILES_FOLDER, BaseTest, NullOutput
+
+
+def _atom_feed(entry_ids, next_url=None):
+    next_link = ""
+    if next_url is not None:
+        next_link = f'<link href="{next_url}" rel="next"/>'
+    entries = "".join(
+        f"""
+        <entry>
+          <title>Item {entry_id}</title>
+          <id>tag:example.org,2024:{entry_id}</id>
+          <updated>2024-01-01T12:00:00Z</updated>
+          <content type="html">Item {entry_id}</content>
+        </entry>
+        """
+        for entry_id in entry_ids
+    )
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <title>Paged feed</title>
+      <link href="{BASE_URL}" rel="self"/>
+      {next_link}
+      <updated>2024-01-01T12:00:00Z</updated>
+      {entries}
+    </feed>
+    """.encode("utf-8")
 
 
 @requests_mock.Mocker()
@@ -45,6 +72,141 @@ class XMLFeedsTest(BaseTest):
         titles = {p.title for p in src.posts.all()}
         self.assertIn("First page item", titles)
         self.assertIn("Second page item", titles)
+
+    def test_atom_stops_at_repeated_pagination_url(self, mock):
+        mock.register_uri(
+            "GET",
+            BASE_URL,
+            status_code=200,
+            content=_atom_feed(["first"], next_url=BASE_URL),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.posts.count(), 1)
+        self.assertEqual(len(mock.request_history), 1)
+        self.assertEqual(src.last_result, "Pagination stopped at repeated URL")
+
+    def test_atom_stops_at_two_url_pagination_cycle(self, mock):
+        second_url = BASE_URL + "page-2.xml"
+        mock.register_uri(
+            "GET",
+            BASE_URL,
+            status_code=200,
+            content=_atom_feed(["first"], next_url=second_url),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        mock.register_uri(
+            "GET",
+            second_url,
+            status_code=200,
+            content=_atom_feed(["second"], next_url=BASE_URL),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.posts.count(), 2)
+        self.assertEqual(len(mock.request_history), 2)
+        self.assertEqual(src.last_result, "Pagination stopped at repeated URL")
+
+    @override_settings(FEEDS_MAX_PAGINATION_PAGES=1)
+    def test_atom_stops_at_pagination_page_limit(self, mock):
+        second_url = BASE_URL + "page-2.xml"
+        third_url = BASE_URL + "page-3.xml"
+        mock.register_uri(
+            "GET",
+            BASE_URL,
+            status_code=200,
+            content=_atom_feed(["first"], next_url=second_url),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        mock.register_uri(
+            "GET",
+            second_url,
+            status_code=200,
+            content=_atom_feed(["second"], next_url=third_url),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.posts.count(), 2)
+        self.assertEqual(len(mock.request_history), 2)
+        self.assertEqual(src.last_result, "Pagination stopped at 1 page")
+
+    @override_settings(FEEDS_MAX_PAGINATION_ENTRIES=2)
+    def test_atom_stops_at_total_entry_limit(self, mock):
+        second_url = BASE_URL + "page-2.xml"
+        mock.register_uri(
+            "GET",
+            BASE_URL,
+            status_code=200,
+            content=_atom_feed(["first"], next_url=second_url),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        mock.register_uri(
+            "GET",
+            second_url,
+            status_code=200,
+            content=_atom_feed(["second", "third"]),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.posts.count(), 2)
+        self.assertEqual(src.last_result, "Pagination stopped at 2 entries")
+
+    def test_atom_stops_when_pagination_request_fails(self, mock):
+        second_url = BASE_URL + "page-2.xml"
+        mock.register_uri(
+            "GET",
+            BASE_URL,
+            status_code=200,
+            content=_atom_feed(["first"], next_url=second_url),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        mock.register_uri("GET", second_url, status_code=503)
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.posts.count(), 1)
+        self.assertTrue(src.last_result.startswith("Pagination request failed:"))
+
+    def test_atom_does_not_request_unsafe_pagination_url(self, mock):
+        mock.register_uri(
+            "GET",
+            BASE_URL,
+            status_code=200,
+            content=_atom_feed(["first"], next_url="http://127.0.0.1/private"),
+            headers={"Content-Type": "application/atom+xml"},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.posts.count(), 1)
+        self.assertEqual(len(mock.request_history), 1)
+        self.assertEqual(src.last_result, "Pagination stopped at unsafe URL")
 
     def test_item_without_enclosures_list(self, mock):
         """Entries without an enclosures key must not raise KeyError."""

--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -260,6 +260,9 @@ def _read_feed_process_success_body(
     ok = True
     changed = False
 
+    if hasattr(source_feed, "_pagination_result"):
+        del source_feed._pagination_result
+
     _read_feed_store_validator_headers(source_feed, ret, was302)
 
     output.write(
@@ -276,14 +279,15 @@ def _read_feed_process_success_body(
         content_type=content_type,
         output=output,
     )
+    pagination_result = getattr(source_feed, "_pagination_result", None)
 
     if ok and changed:
         source_feed.interval /= 2
-        source_feed.last_result = " OK (updated)"
+        source_feed.last_result = pagination_result or " OK (updated)"
         source_feed.last_change = timezone.now()
 
     elif ok:
-        source_feed.last_result = " OK"
+        source_feed.last_result = pagination_result or " OK"
         source_feed.interval += 20
     else:
         source_feed.interval += 120

--- a/feeds/utils_internal.py
+++ b/feeds/utils_internal.py
@@ -12,6 +12,13 @@ from django.conf import settings
 from django.utils import timezone
 
 from feeds.models import Enclosure, Post, Source
+from feeds.url_safety import (
+    is_safe_http_redirect_target,
+    resolve_feed_redirect_location,
+)
+
+DEFAULT_MAX_PAGINATION_PAGES = 20
+DEFAULT_MAX_PAGINATION_ENTRIES = 2000
 
 VERIFY_HTTPS = True
 if hasattr(settings, "FEEDS_VERIFY_HTTPS"):
@@ -31,6 +38,31 @@ if hasattr(settings, "FEEDS_USER_AGENT"):
 
 
 logger = logging.getLogger(__file__)
+
+
+def _positive_int_setting(name: str, default: int) -> int:
+    """Return a positive integer setting, falling back for invalid values."""
+    try:
+        value = int(getattr(settings, name, default))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _pagination_limit(name: str, value: int) -> str:
+    unit = name[:-1] if value == 1 else name
+    return f"Pagination stopped at {value} {unit}"
+
+
+def _next_feed_page(feed, current_url: str):
+    """Return the resolved first rel=next URL, or None when pagination is complete."""
+    for link in getattr(feed.feed, "links", []):
+        if link.get("rel") == "next":
+            href = link.get("href", "")
+            if not isinstance(href, str):
+                return ""
+            return resolve_feed_redirect_location(href, current_url)
+    return None
 
 
 def _posts_by_guid_lookup(source_feed: Source) -> dict:
@@ -320,18 +352,25 @@ def parse_feed(source_feed: Source, feed_body, content_type, output: TextIO):
     return (ok, changed)
 
 
-def parse_feed_xml(source_feed, feed_content, output: TextIO):
+def parse_feed_xml(source_feed, feed_content, output: TextIO, max_entries=None):
 
     ok = True
     changed = False
 
     is_first = not source_feed.posts.exists()
+    if is_first and max_entries is None:
+        max_entries = _positive_int_setting(
+            "FEEDS_MAX_PAGINATION_ENTRIES", DEFAULT_MAX_PAGINATION_ENTRIES
+        )
 
     # output.write(ret.content)
     try:
         _customize_sanitizer(parser)
         f = parser.parse(feed_content)  # need to start checking feed parser errors here
         entries = f["entries"]
+        entries_available = len(entries)
+        if max_entries is not None:
+            entries = entries[:max_entries]
         if len(entries):
             source_feed.last_success = (
                 timezone.now()
@@ -492,28 +531,89 @@ def parse_feed_xml(source_feed, feed_content, output: TextIO):
         # then see if it's paginated and go back through its history
         agent = get_agent(source_feed)
         headers = {"User-Agent": agent}  # identify ourselves
-        keep_going = True
-        while keep_going:
-            keep_going = False  # assume were stopping unless we find a next link
-            if hasattr(f.feed, "links"):
-                for link in f.feed.links:
-                    if "rel" in link and link["rel"] == "next":
-                        ret = requests.get(
-                            link["href"],
-                            headers=headers,
-                            verify=VERIFY_HTTPS,
-                            allow_redirects=True,
-                            timeout=20,
-                        )
-                        (pok, pchanged) = parse_feed_xml(
-                            source_feed, ret.content, output
-                        )
-                        # print(link['href'])
-                        # print((pok, pchanged))
-                        f = parser.parse(
-                            ret.content
-                        )  # rebase the loop on this feed version
-                        keep_going = True
+        max_pages = _positive_int_setting(
+            "FEEDS_MAX_PAGINATION_PAGES", DEFAULT_MAX_PAGINATION_PAGES
+        )
+        max_total_entries = _positive_int_setting(
+            "FEEDS_MAX_PAGINATION_ENTRIES", DEFAULT_MAX_PAGINATION_ENTRIES
+        )
+        entries_processed = min(entries_available, max_total_entries)
+        pages_fetched = 0
+        current_url = source_feed.feed_url
+        visited_urls = {current_url}
+
+        if entries_available > max_total_entries:
+            source_feed._pagination_result = _pagination_limit(
+                "entries", max_total_entries
+            )
+
+        while not hasattr(source_feed, "_pagination_result"):
+            next_url = _next_feed_page(f, current_url)
+            if next_url is None:
+                break
+            if not is_safe_http_redirect_target(next_url):
+                source_feed._pagination_result = "Pagination stopped at unsafe URL"
+                break
+            if next_url in visited_urls:
+                source_feed._pagination_result = "Pagination stopped at repeated URL"
+                break
+            if pages_fetched >= max_pages:
+                source_feed._pagination_result = _pagination_limit("pages", max_pages)
+                break
+            if entries_processed >= max_total_entries:
+                source_feed._pagination_result = _pagination_limit(
+                    "entries", max_total_entries
+                )
+                break
+
+            try:
+                ret = requests.get(
+                    next_url,
+                    headers=headers,
+                    verify=VERIFY_HTTPS,
+                    allow_redirects=False,
+                    timeout=20,
+                )
+            except (requests.RequestException, OSError) as ex:
+                source_feed._pagination_result = (
+                    "Pagination request failed: " + str(ex)
+                )[:255]
+                break
+
+            if ret.status_code < 200 or ret.status_code >= 300:
+                source_feed._pagination_result = (
+                    f"Pagination request failed: HTTP {ret.status_code}"
+                )
+                break
+
+            if not ret.content:
+                source_feed._pagination_result = "Pagination stopped at empty response"
+                break
+
+            remaining_entries = max_total_entries - entries_processed
+            page_feed = parser.parse(ret.content)
+            page_entries = page_feed.get("entries", [])
+            (page_ok, _page_changed) = parse_feed_xml(
+                source_feed,
+                ret.content,
+                output,
+                max_entries=remaining_entries,
+            )
+            if not page_ok:
+                source_feed._pagination_result = "Pagination stopped at invalid feed"
+                break
+
+            pages_fetched += 1
+            entries_processed += min(len(page_entries), remaining_entries)
+            visited_urls.add(next_url)
+            current_url = ret.url or next_url
+            visited_urls.add(current_url)
+            f = page_feed
+
+            if len(page_entries) > remaining_entries:
+                source_feed._pagination_result = _pagination_limit(
+                    "entries", max_total_entries
+                )
 
     return (ok, changed)
 


### PR DESCRIPTION
## Outcome and motivation

Prevent a new XML/Atom source with circular or effectively endless `rel="next"` history pagination from monopolizing the serial feed polling queue. Issue #43 reported a single feed importing thousands of posts indefinitely and preventing later feeds from starting.

Closes #43

## Scope

- Bound first-import history backfill to 20 additional pages and 2,000 total entries by default.
- Allow both limits to be overridden with positive-integer Django settings.
- Detect repeated pagination URLs before requesting them.
- Resolve relative page links and reject unsafe HTTP targets.
- Stop cleanly on non-2xx, empty, invalid, or failed pagination responses.
- Preserve posts already imported and persist an operator-facing stop reason in `Source.last_result`.
- Keep existing public utility signatures and database schema unchanged.

Non-goals: parallelizing `update_feeds()`, adding a per-source model field, DNS-based SSRF protection, or changing routine polling after a source's initial backfill.

## Acceptance criteria

- A self-referencing or cyclic pagination chain terminates without requesting a repeated URL.
- At most 20 additional pages and 2,000 total entries are processed during initial backfill by default.
- `FEEDS_MAX_PAGINATION_PAGES` and `FEEDS_MAX_PAGINATION_ENTRIES` override those defaults; invalid or non-positive values fall back to the defaults.
- Pagination stops on an unsafe URL, redirect/non-2xx response, request error, empty response, or invalid feed without discarding posts already imported.
- A normal finite `rel="next"` chain continues to import all available entries within the limits.
- Existing public APIs and schema remain compatible.

## Implementation decisions

Pagination remains an internal iterative workflow. The initial response is not counted against the page setting; `FEEDS_MAX_PAGINATION_PAGES` limits additional page requests. Entry limits count feed entries processed across the initial and additional pages, including duplicates, so processing work is bounded independently of database deduplication. Pagination redirects are not followed because their destination would bypass target validation.

## Validation

- `.venv/bin/pytest --reuse-db feeds/tests/test_xml_feeds.py feeds/tests/test_http.py feeds/tests/test_poll_utils.py feeds/tests/test_url_safety.py -q` — 56 passed.
- `.venv/bin/pytest --reuse-db` — 101 passed.
- `git diff --check` — passed.

Regression coverage includes finite pagination, self-reference, a two-URL cycle, page and entry limits, failed pagination responses, and unsafe pagination targets.

## Data, security, and rollout

No migration or data rewrite is required. Existing deployments receive conservative defaults automatically and may tune them through Django settings. The change narrows the outbound-request surface by validating pagination targets and refusing pagination redirects. Hostnames are still not DNS-resolved before requests, matching the repository's existing URL-safety boundary.

## Known risks

Feeds with more history than the configured limits will retain the imported prefix and report truncation in `last_result`. Deployments that intentionally require deeper history can raise either setting, trading longer first-poll time for more history.
