### PR TITLE
fix: validate every redirect hop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 
 ### 2.0.1
+- Security: Validate DNS results and every hop in bounded manual redirect chains before connecting
 - Fix: Bound first-import XML/Atom pagination, detect repeated page URLs, and stop cleanly on failed pagination responses
 - Fix: `get_unread_subscription_list_for_user` no longer returns read-only folder subscriptions as unread
 - Fix: Paginated feed import (`rel="next"`) when backfilling history for a new source

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -106,8 +106,9 @@ Evidence: model fields, constraints, save behavior, and signals in
 
 - **HTTP-001** — Feed requests shall use a user agent containing the configured
   user-agent label, server identity, updater role, and source subscriber count.
-- **HTTP-002** — Direct feed requests shall use a 20-second timeout, configurable
-  TLS verification, and disabled automatic redirects for the first request.
+- **HTTP-002** — Feed requests shall use a 20-second timeout, configurable TLS
+  verification, and disabled automatic redirects. Redirects shall be followed
+  explicitly as described below.
 - **HTTP-003** — Stored ETag and Last-Modified values shall be sent as conditional
   request headers. Validator values from successful non-temporary responses shall
   replace the stored values.
@@ -132,17 +133,21 @@ Evidence: model fields, constraints, save behavior, and signals in
 - **REDIR-001** — A 301 or 308 response with a valid safe Location shall replace
   the stored feed URL. Its body shall not be fetched until a later poll.
 - **REDIR-002** — A 302, 303, or 307 response with a valid safe Location shall be
-  followed for the current poll. If the same temporary target persists for more
-  than 60 days, it shall replace the stored feed URL.
+  followed manually for the current poll, including subsequent 301, 302, 303, 307,
+  and 308 responses, up to 10 hops. Repeated targets shall terminate the chain. If
+  the same initial temporary target persists for more than 60 days, it shall
+  replace the stored feed URL.
 - **REDIR-003** — Relative Location values shall be resolved against the current
-  feed URL.
+  response URL.
 - **SEC-001** — Redirect targets shall be absolute HTTP(S) URLs with a host. Literal
   private, loopback, link-local, reserved, multicast, and metadata IP addresses,
   plus `localhost`, `.localhost`, `.local`, and the configured metadata hostname,
-  shall be rejected.
-- **SEC-002** — Redirect validation does not DNS-resolve hostnames and does not
-  validate initial source URLs or pagination links. This observed boundary is
-  subject to assumption A-004.
+  shall be rejected. Hostnames shall resolve successfully, and every returned
+  address shall be globally routable before a redirect request is made.
+- **SEC-002** — Initial source URLs and pagination links are not DNS-resolved before
+  requests. Redirect DNS validation is a pre-request check and does not pin the
+  connection address, so DNS rebinding remains outside the observed protection.
+  This boundary is subject to assumption A-004.
 
 Evidence: `feeds/utils.py`; `feeds/url_safety.py`;
 `feeds/tests/test_http.py`; `feeds/tests/test_url_safety.py`.
@@ -309,9 +314,9 @@ Evidence: `AGENTS.md`; `setup.py`; `feeds/models.py`;
   cycles are not rejected by model validation or database constraints.
 - **GAP-004 — Ignored pagination direction:**
   `Subscription.get_paginated_posts(oldest_first=...)` always orders newest first.
-- **GAP-005 — Partial SSRF boundary:** redirect targets are checked syntactically
-  and for literal unsafe IPs, but initial URLs and paginated links are unchecked and
-  hostnames are not DNS-resolved before requests.
+- **GAP-005 — Partial SSRF boundary:** redirect targets and their DNS results are
+  checked before each hop, but initial URLs and paginated links are not DNS-resolved
+  and redirect connections are not pinned against DNS rebinding.
 - **GAP-006 — Expired JSON polling:** an expired JSON Feed sets a three-day interval
   internally, but normal finalization clamps it to one day and leaves the source
   live.
@@ -365,7 +370,7 @@ Provisional interpretation: comprehensive SSRF protection is desirable for every
 URL fetched by the library, not only explicit redirects.
 
 Evidence: redirect hardening and tests; direct source and paginated requests bypass
-the validator; hostname validation does not resolve DNS.
+DNS validation, and redirect connections are not address-pinned.
 
 Confidence: medium.
 

--- a/feeds/tests/test_http.py
+++ b/feeds/tests/test_http.py
@@ -1,5 +1,7 @@
+import socket
 from datetime import timedelta
 from importlib import reload
+from unittest.mock import patch
 
 import requests
 import requests_mock
@@ -15,6 +17,15 @@ from .base import BASE_URL, BaseTest, NullOutput
 
 @requests_mock.Mocker()
 class HTTPStuffTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        dns_patcher = patch("feeds.url_safety.socket.getaddrinfo")
+        self.mock_getaddrinfo = dns_patcher.start()
+        self.addCleanup(dns_patcher.stop)
+        self.mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))
+        ]
+
     def test_etags(self, mock):
 
         self._populate_mock(
@@ -362,6 +373,74 @@ class HTTPStuffTest(BaseTest):
         self.assertEqual(src.posts.count(), 0)
         self.assertEqual(src.feed_url, BASE_URL)
 
+    def test_temp_redirect_rejects_unsafe_later_hop(self, mock):
+        safe_url = "http://safe.example/feed"
+        unsafe_url = "http://127.0.0.1/internal"
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": safe_url},
+        )
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": unsafe_url},
+            url=safe_url,
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(len(mock.request_history), 2)
+        self.assertEqual(src.last_result, "Unsafe or invalid redirect URL")
+        self.assertEqual(src.posts.count(), 0)
+
+    def test_temp_redirect_rejects_hostname_resolving_private(self, mock):
+        safe_looking_url = "http://internal.example/feed"
+        self.mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 80))
+        ]
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": safe_looking_url},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(len(mock.request_history), 1)
+        self.assertEqual(src.last_result, "Unsafe redirect address")
+
+    def test_temp_redirect_dns_failure_stops_before_request(self, mock):
+        safe_looking_url = "http://missing.example/feed"
+        self.mock_getaddrinfo.side_effect = socket.gaierror
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": safe_looking_url},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(len(mock.request_history), 1)
+        self.assertEqual(src.last_result, "Redirect hostname resolution failed")
+
     def test_perm_redirect_rejects_unsafe_location(self, mock):
 
         unsafe = "http://127.0.0.1/internal"
@@ -380,6 +459,27 @@ class HTTPStuffTest(BaseTest):
         src.refresh_from_db()
 
         self.assertEqual(src.last_result, "Unsafe or invalid redirect URL")
+        self.assertEqual(src.feed_url, BASE_URL)
+
+    def test_perm_redirect_rejects_hostname_resolving_private(self, mock):
+        safe_looking_url = "http://internal.example/feed"
+        self.mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.2", 80))
+        ]
+        self._populate_mock(
+            mock,
+            status=301,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": safe_looking_url},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.last_result, "Unsafe redirect address")
         self.assertEqual(src.feed_url, BASE_URL)
 
     def test_empty_response_body(self, mock):
@@ -441,6 +541,94 @@ class HTTPStuffTest(BaseTest):
 
         self.assertEqual(src.status_code, 200)
         self.assertEqual(src.posts.count(), 1)
+
+    def test_temp_redirect_safe_multi_hop_relative_location(self, mock):
+        first_url = "http://safe.example/first.xml"
+        final_url = "http://safe.example/final.xml"
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": first_url},
+        )
+        self._populate_mock(
+            mock,
+            status=307,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": "/final.xml"},
+            url=first_url,
+        )
+        self._populate_mock(
+            mock,
+            status=200,
+            test_file="rss_xhtml_body.xml",
+            content_type="application/xml+rss",
+            url=final_url,
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(len(mock.request_history), 3)
+        self.assertEqual(src.status_code, 200)
+        self.assertEqual(src.posts.count(), 1)
+
+    def test_temp_redirect_loop_stops_before_repeated_request(self, mock):
+        first_url = "http://safe.example/first.xml"
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": first_url},
+        )
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": BASE_URL},
+            url=first_url,
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(len(mock.request_history), 2)
+        self.assertEqual(src.last_result, "Redirect loop detected")
+
+    def test_temp_redirect_hop_limit(self, mock):
+        first_url = BASE_URL + "redirect/1"
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": first_url},
+        )
+        for hop in range(1, 11):
+            self._populate_mock(
+                mock,
+                status=302,
+                test_file="empty_file.txt",
+                content_type="text/plain",
+                headers={"Location": BASE_URL + f"redirect/{hop + 1}"},
+                url=BASE_URL + f"redirect/{hop}",
+            )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(len(mock.request_history), 11)
+        self.assertEqual(src.last_result, "Redirect hop limit exceeded")
 
     def test_temp_redirect(self, mock):
 

--- a/feeds/tests/test_http.py
+++ b/feeds/tests/test_http.py
@@ -401,6 +401,24 @@ class HTTPStuffTest(BaseTest):
         self.assertEqual(src.last_result, "Unsafe or invalid redirect URL")
         self.assertEqual(src.posts.count(), 0)
 
+    def test_temp_redirect_rejects_backslash_authority_ambiguity(self, mock):
+        ambiguous_url = "http://127.0.0.1\\@example.com/"
+        self._populate_mock(
+            mock,
+            status=302,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Location": ambiguous_url},
+        )
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(len(mock.request_history), 1)
+        self.assertEqual(src.last_result, "Unsafe or invalid redirect URL")
+
     def test_temp_redirect_rejects_hostname_resolving_private(self, mock):
         safe_looking_url = "http://internal.example/feed"
         self.mock_getaddrinfo.return_value = [

--- a/feeds/tests/test_url_safety.py
+++ b/feeds/tests/test_url_safety.py
@@ -1,11 +1,15 @@
 """Tests for redirect URL validation and default FEEDS_SERVER derivation."""
 
+import socket
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
 from feeds.url_safety import (
     derive_default_feeds_server,
     is_safe_http_redirect_target,
     resolve_feed_redirect_location,
+    validate_http_redirect_target,
 )
 
 
@@ -60,3 +64,46 @@ class IsSafeHttpRedirectTargetTests(SimpleTestCase):
 
     def test_rejects_empty(self):
         self.assertFalse(is_safe_http_redirect_target(""))
+
+    @patch("feeds.url_safety.socket.getaddrinfo")
+    def test_dns_validation_allows_public_addresses(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                ("2606:2800:220:1:248:1893:25c8:1946", 80, 0, 0),
+            ),
+        ]
+
+        safe, reason = validate_http_redirect_target(
+            "http://public.example/feed", resolve_hostname=True
+        )
+
+        self.assertTrue(safe)
+        self.assertEqual(reason, "")
+
+    @patch("feeds.url_safety.socket.getaddrinfo")
+    def test_dns_validation_rejects_any_private_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 80)),
+        ]
+
+        safe, reason = validate_http_redirect_target(
+            "http://mixed.example/feed", resolve_hostname=True
+        )
+
+        self.assertFalse(safe)
+        self.assertEqual(reason, "Unsafe redirect address")
+
+    @patch("feeds.url_safety.socket.getaddrinfo", side_effect=socket.gaierror)
+    def test_dns_validation_fails_closed(self, _mock_getaddrinfo):
+        safe, reason = validate_http_redirect_target(
+            "http://missing.example/feed", resolve_hostname=True
+        )
+
+        self.assertFalse(safe)
+        self.assertEqual(reason, "Redirect hostname resolution failed")

--- a/feeds/tests/test_url_safety.py
+++ b/feeds/tests/test_url_safety.py
@@ -65,6 +65,13 @@ class IsSafeHttpRedirectTargetTests(SimpleTestCase):
     def test_rejects_empty(self):
         self.assertFalse(is_safe_http_redirect_target(""))
 
+    def test_rejects_backslash_authority_ambiguity(self):
+        self.assertFalse(
+            is_safe_http_redirect_target(
+                "http://127.0.0.1\\@example.com/", resolve_hostname=True
+            )
+        )
+
     @patch("feeds.url_safety.socket.getaddrinfo")
     def test_dns_validation_allows_public_addresses(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [

--- a/feeds/url_safety.py
+++ b/feeds/url_safety.py
@@ -61,6 +61,11 @@ def validate_http_redirect_target(
     invalid_result = (False, "Unsafe or invalid redirect URL")
     if not url or not isinstance(url, str):
         return invalid_result
+    # Requests and urllib.parse disagree about backslashes in URL authorities.
+    # Reject them before parsing so validation and connection cannot target
+    # different hosts (for example, ``127.0.0.1\\@example.com``).
+    if "\\" in url:
+        return invalid_result
     try:
         parsed = urlparse(url)
     except (TypeError, ValueError):

--- a/feeds/url_safety.py
+++ b/feeds/url_safety.py
@@ -1,11 +1,14 @@
 """Validate HTTP(S) redirect targets to reduce SSRF risk when following Location headers."""
 
 import ipaddress
+import socket
+from typing import Tuple
 from urllib.parse import urljoin, urlparse
 
 __all__ = [
     "resolve_feed_redirect_location",
     "is_safe_http_redirect_target",
+    "validate_http_redirect_target",
     "derive_default_feeds_server",
 ]
 
@@ -43,47 +46,70 @@ def resolve_feed_redirect_location(location: str, feed_url: str) -> str:
     return urljoin(base, loc)
 
 
-def is_safe_http_redirect_target(url: str) -> bool:
-    """
-    Return True if url is an absolute http(s) URL with a host that is not obviously
-    private, loopback, link-local, or cloud metadata. Hostnames are not DNS-resolved.
-    """
-    if not url or not isinstance(url, str):
+def _is_safe_ip_address(address: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
         return False
+    return ip.is_global
+
+
+def validate_http_redirect_target(
+    url: str, resolve_hostname: bool = False
+) -> Tuple[bool, str]:
+    """Validate a redirect URL and optionally all addresses returned by DNS."""
+    invalid_result = (False, "Unsafe or invalid redirect URL")
+    if not url or not isinstance(url, str):
+        return invalid_result
     try:
         parsed = urlparse(url)
     except (TypeError, ValueError):
-        return False
+        return invalid_result
     scheme = (parsed.scheme or "").lower()
     if scheme not in ("http", "https"):
-        return False
+        return invalid_result
     host = parsed.hostname
     if not host:
-        return False
+        return invalid_result
     host_lower = host.lower().rstrip(".")
     if host_lower in _BLOCKED_HOSTNAMES:
-        return False
+        return invalid_result
     if host_lower.endswith(".local") or host_lower.endswith(".localhost"):
-        return False
-
-    # Strip IPv6 brackets for ipaddress
-    host_for_ip = host_lower
-    if host_for_ip.startswith("[") and host_for_ip.endswith("]"):
-        host_for_ip = host_for_ip[1:-1]
+        return invalid_result
 
     try:
-        ip = ipaddress.ip_address(host_for_ip)
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-        ):
-            return False
-        if ip == ipaddress.ip_address("169.254.169.254"):
-            return False
+        ipaddress.ip_address(host_lower)
     except ValueError:
-        pass
+        if not resolve_hostname:
+            return (True, "")
+    else:
+        return (True, "") if _is_safe_ip_address(host_lower) else invalid_result
 
-    return True
+    try:
+        port = parsed.port or (443 if scheme == "https" else 80)
+        addresses = socket.getaddrinfo(
+            host_lower,
+            port,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+        )
+    except (OSError, ValueError):
+        return (False, "Redirect hostname resolution failed")
+
+    if not addresses:
+        return (False, "Redirect hostname resolution failed")
+    for address_info in addresses:
+        try:
+            address = address_info[4][0]
+        except (IndexError, TypeError):
+            return (False, "Redirect hostname resolution failed")
+        if not _is_safe_ip_address(address):
+            return (False, "Unsafe redirect address")
+
+    return (True, "")
+
+
+def is_safe_http_redirect_target(url: str, resolve_hostname: bool = False) -> bool:
+    """Return whether a redirect target passes URL and optional DNS checks."""
+    safe, _reason = validate_http_redirect_target(url, resolve_hostname)
+    return safe

--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -11,8 +11,8 @@ from dripfeed import DripFeed, DripFeedException
 
 from feeds.models import Source, Subscription
 from feeds.url_safety import (
-    is_safe_http_redirect_target,
     resolve_feed_redirect_location,
+    validate_http_redirect_target,
 )
 from feeds.utils_internal import (
     VERIFY_HTTPS,
@@ -29,6 +29,9 @@ if hasattr(settings, "FEEDS_CLOUDFLARE_WORKER"):
     CLOUDFLARE_WORKER = settings.FEEDS_CLOUDFLARE_WORKER
 
 logger = logging.getLogger(__file__)
+
+REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+MAX_REDIRECT_HOPS = 10
 
 
 def update_feeds(max_feeds: int = 3, output: TextIO = stdout):
@@ -92,8 +95,11 @@ def _read_feed_apply_permanent_redirect(
         return
     raw_location = ret.headers["Location"]
     resolved = resolve_feed_redirect_location(raw_location, source_feed.feed_url)
-    if not resolved or not is_safe_http_redirect_target(resolved):
-        source_feed.last_result = "Unsafe or invalid redirect URL"
+    safe, failure_reason = validate_http_redirect_target(
+        resolved, resolve_hostname=True
+    )
+    if not safe:
+        source_feed.last_result = failure_reason
         return
     source_feed.feed_url = resolved
     source_feed.last_result = "Moved"
@@ -107,22 +113,45 @@ def _read_feed_follow_temporary_redirect(
     headers: dict,
 ) -> requests.Response:
     new_url = ""
+    current_url = ret.url or source_feed.feed_url
+    visited_urls = {current_url}
+    redirect_hops = 0
     try:
-        raw_location = ret.headers["Location"]
-        resolved = resolve_feed_redirect_location(raw_location, source_feed.feed_url)
-        if not resolved or not is_safe_http_redirect_target(resolved):
-            source_feed.last_result = "Unsafe or invalid redirect URL"
-            source_feed.interval += 60
-            return ret
-        new_url = resolved
-        ret = requests.get(
-            new_url,
-            headers=headers,
-            allow_redirects=True,
-            timeout=20,
-            verify=VERIFY_HTTPS,
-        )
-        source_feed.status_code = ret.status_code
+        while ret.status_code in REDIRECT_STATUS_CODES:
+            if redirect_hops >= MAX_REDIRECT_HOPS:
+                source_feed.last_result = "Redirect hop limit exceeded"
+                source_feed.interval += 60
+                return ret
+
+            raw_location = ret.headers["Location"]
+            resolved = resolve_feed_redirect_location(raw_location, current_url)
+            safe, failure_reason = validate_http_redirect_target(
+                resolved, resolve_hostname=True
+            )
+            if not safe:
+                source_feed.last_result = failure_reason
+                source_feed.interval += 60
+                return ret
+            if resolved in visited_urls:
+                source_feed.last_result = "Redirect loop detected"
+                source_feed.interval += 60
+                return ret
+
+            if not new_url:
+                new_url = resolved
+            visited_urls.add(resolved)
+            ret = requests.get(
+                resolved,
+                headers=headers,
+                allow_redirects=False,
+                timeout=20,
+                verify=VERIFY_HTTPS,
+            )
+            source_feed.status_code = ret.status_code
+            current_url = ret.url or resolved
+            visited_urls.add(current_url)
+            redirect_hops += 1
+
         source_feed.last_result = ("Temporary Redirect to " + new_url)[:255]
 
         if source_feed.last_302_url == new_url:


### PR DESCRIPTION
## Outcome and motivation

Close an SSRF boundary failure in feed redirects. Previously the first temporary redirect target was validated, but it was fetched with automatic redirects enabled, allowing later hops to connect to unchecked loopback, private-network, link-local, metadata, or otherwise unsafe destinations.

Closes #46

## Scope

- Follow temporary redirect chains manually with Requests automatic redirects disabled.
- Validate every redirect destination before connecting.
- Resolve hostnames before redirect requests and reject the destination if DNS fails or any returned address is not globally routable.
- Support relative and absolute 301, 302, 303, 307, and 308 hops.
- Stop repeated-URL chains and limit each poll to 10 redirect hops.
- Apply DNS-aware validation before persisting permanent redirect destinations.
- Preserve the existing public utility signatures, temporary-target aging behavior, and database schema.

Non-goals: validating user-supplied initial source URLs, adding DNS validation to pagination, changing HTTP status policy, or implementing connection-time address pinning.

## Acceptance criteria

- No redirect request uses automatic redirect following.
- A safe first hop cannot redirect the poller to a blocked literal destination.
- A hostname resolving to any private or otherwise non-global address is rejected before a request.
- Redirect URLs containing backslashes are rejected so `urllib.parse` validation cannot disagree with Requests about the destination host.
- DNS resolution failure stops redirect following without an unchecked fallback.
- Safe relative and absolute multi-hop redirects continue to work.
- Redirect loops stop before a repeated request.
- No more than 10 redirect hops are requested per poll.
- Existing public APIs and schema remain compatible.

## Implementation decisions

`validate_http_redirect_target()` provides reason-returning validation and optional DNS checks while the existing boolean validator remains compatible for syntax-only callers. DNS validation fails closed and requires every address returned by `getaddrinfo()` to be globally routable. Literal IPs are evaluated directly.

Temporary redirect tracking continues to use the first temporary target, matching existing behavior. A later permanent status in that same chain is followed only for the current poll; an initial 301/308 retains the existing behavior of updating the stored URL for a later poll.

## Validation

- `.venv/bin/pytest --reuse-db feeds/tests/test_url_safety.py feeds/tests/test_http.py feeds/tests/test_xml_feeds.py -q` — 63 passed.
- `.venv/bin/pytest --reuse-db` — 113 passed.
- `git diff --check` — passed.

Regression coverage includes the reported safe-to-loopback chain, mixed public/private DNS answers, DNS failure, safe multi-hop relative redirects, cycles, the 10-hop boundary, permanent redirect DNS validation, and a backslash authority parser-confusion payload.

## Data, security, and rollout

No migration or data rewrite is required. Redirects to internal-only feed hosts will now be rejected, including hostnames with mixed public/private answers. Operators will see a bounded failure reason in `Source.last_result` and the feed remains eligible for later polling under existing interval behavior.

## Known limitation

DNS validation occurs before the request but does not pin the connection to the validated address. DNS rebinding between validation and connection therefore remains possible. Closing that gap requires a broader transport design covering TLS hostname verification, proxies, and custom connection adapters; it is intentionally outside this issue.
