### PR TITLE
fix: reactivate retained enclosures

### DIFF
--- a/feeds/testdata/json_attachment_a.json
+++ b/feeds/testdata/json_attachment_a.json
@@ -1,0 +1,20 @@
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "title": "Attachment cycle",
+    "home_page_url": "https://example.org/",
+    "items": [
+        {
+            "id": "attachment-cycle-item",
+            "title": "Attachment cycle item",
+            "content_text": "An attachment that changes over time.",
+            "url": "https://example.org/attachment-cycle-item",
+            "attachments": [
+                {
+                    "url": "https://example.org/attachment-a.mp3",
+                    "mime_type": "audio/mpeg",
+                    "size_in_bytes": 100
+                }
+            ]
+        }
+    ]
+}

--- a/feeds/testdata/json_attachment_b.json
+++ b/feeds/testdata/json_attachment_b.json
@@ -1,0 +1,20 @@
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "title": "Attachment cycle",
+    "home_page_url": "https://example.org/",
+    "items": [
+        {
+            "id": "attachment-cycle-item",
+            "title": "Attachment cycle item",
+            "content_text": "An attachment that changes over time.",
+            "url": "https://example.org/attachment-cycle-item",
+            "attachments": [
+                {
+                    "url": "https://example.org/attachment-b.mp3",
+                    "mime_type": "audio/mpeg",
+                    "size_in_bytes": 200
+                }
+            ]
+        }
+    ]
+}

--- a/feeds/tests/test_json_feeds.py
+++ b/feeds/tests/test_json_feeds.py
@@ -128,6 +128,54 @@ class JSONFeedTest(BaseTest):
 
         self.assertEqual(post.enclosures.count(), 1)
 
+    def test_keep_old_attachment_reactivates_returning_url(self, mock):
+
+        settings.FEEDS_KEEP_OLD_ENCLOSURES = True
+
+        # to pick up the settings change
+        reload(utils)
+        reload(utils_internal)
+
+        self._populate_mock(
+            mock,
+            status=200,
+            test_file="json_attachment_a.json",
+            content_type="application/json",
+        )
+
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+
+        self._populate_mock(
+            mock,
+            status=200,
+            test_file="json_attachment_b.json",
+            content_type="application/json",
+        )
+
+        read_feed(src, output=NullOutput())
+
+        self._populate_mock(
+            mock,
+            status=200,
+            test_file="json_attachment_a.json",
+            content_type="application/json",
+        )
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        post = src.posts.get()
+        self.assertEqual(post.enclosures.count(), 2)
+        self.assertEqual(post.current_enclosures.count(), 1)
+        self.assertEqual(post.old_enclosures.count(), 1)
+        self.assertEqual(
+            post.current_enclosures.get().href,
+            "https://example.org/attachment-a.mp3",
+        )
+
     def test_expired_json_feed(self, mock):
         """parse_feed_json must return a 2-tuple for expired feeds."""
 

--- a/feeds/tests/test_xml_feeds.py
+++ b/feeds/tests/test_xml_feeds.py
@@ -371,6 +371,25 @@ class XMLFeedsTest(BaseTest):
             "https://static.toot.community/media_attachments/files/111/981/336/553/711/283/original/d83ded1af64141ba_new.jpeg",
         )
 
+        self._populate_mock(
+            mock,
+            status=200,
+            test_file="media_content.xml",
+            content_type="application/rss+xml",
+        )
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        post = src.posts.all()[0]
+        self.assertEqual(post.enclosures.count(), 2)
+        self.assertEqual(post.current_enclosures.count(), 1)
+        self.assertEqual(post.old_enclosures.count(), 1)
+        self.assertEqual(
+            post.current_enclosures.get().href,
+            "https://static.toot.community/media_attachments/files/111/981/336/553/711/283/original/d83ded1af64141ba.jpeg",
+        )
+
     def test_save_json(self, mock):
 
         settings.FEEDS_SAVE_JSON = True

--- a/feeds/utils_internal.py
+++ b/feeds/utils_internal.py
@@ -167,6 +167,7 @@ def _batch_sync_enclosures_normalized(
         for pe in items:
             if pe["href"] == ee.href and ee.href not in seen_files:
                 found_enclosure = True
+                ee.is_current = True
                 ee.length = pe["length"]
                 if "type" in pe:
                     ee.type = pe["type"]


### PR DESCRIPTION
## Outcome

Restore a retained enclosure to current status when its URL reappears in a later version of the same feed item.

## Motivation

With `FEEDS_KEEP_OLD_ENCLOSURES=True`, an A → B → A attachment sequence previously left both retained enclosure records with `is_current=False`. Consumers of `Post.current_enclosures` therefore omitted the attachment currently advertised by the feed.

## Scope

- Reactivate a matched retained enclosure in the shared XML/JSON synchronization path.
- Preserve the existing behavior for absent enclosure URLs: mark them old when retention is enabled, or delete them otherwise.
- Cover the full A → B → A sequence for XML media content and JSON Feed attachments.

Non-goals: changing public APIs, model fields, migrations, attachment deduplication, or retention configuration.

## Acceptance criteria

- [x] Every matched enclosure present in the incoming item is set to `is_current=True`.
- [x] Enclosures absent from the item retain the configured delete-or-old behavior.
- [x] Regression tests cover an A → B → A sequence for XML and JSON attachments.

## Implementation

The normalized enclosure matcher now sets `is_current=True` before adding a matched record to the existing bulk update. XML and JSON callers already include `is_current` in their update field lists.

The regression tests retain both URLs, confirm exactly one current enclosure, and confirm that A is restored as current after it reappears.

## Validation

- Focused XML and JSON regressions: 2 passed.
- Canonical `.venv/bin/pytest --reuse-db`: 102 passed.
- Independent fresh-context verification: all issue criteria verified.
- `git diff --check`: clean.

## Data, security, and rollout

No migration, public API, dependency, security-boundary, or deployment-order changes. Synchronization semantics are classified as high risk by repository policy; the change is limited to one assignment in the existing match branch and is covered through both supported feed formats.

Closes #53
