### PR TITLE
fix: preflight legacy duplicate migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,43 @@ jobs:
           DJANGO_SETTINGS_MODULE: tests.settings
         run: |
           pytest -v --tb=short
+
+  mysql-migrations:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: django_feed_reader
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=root"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "Django>=4.2,<5" mysqlclient
+          pip install -e ".[test]"
+
+      - name: Run MySQL migration tests
+        env:
+          DJANGO_SETTINGS_MODULE: tests.mysql_settings
+          MYSQL_DATABASE: django_feed_reader
+          MYSQL_USER: root
+          MYSQL_PASSWORD: root
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+        run: |
+          pytest feeds/tests/test_migrations.py -v --tb=short

--- a/feeds/migrations/0017_add_integrity_constraints.py
+++ b/feeds/migrations/0017_add_integrity_constraints.py
@@ -2,6 +2,7 @@
 
 from django.db import migrations, models
 
+from ._idempotent_operations import AddConstraintIfMissing
 from ._legacy_duplicate_preflight import preflight_legacy_duplicates
 
 
@@ -15,7 +16,7 @@ class Migration(migrations.Migration):
             preflight_legacy_duplicates,
             migrations.RunPython.noop,
         ),
-        migrations.AddConstraint(
+        AddConstraintIfMissing(
             model_name="post",
             constraint=models.UniqueConstraint(
                 condition=models.Q(("guid__isnull", False)),
@@ -23,13 +24,13 @@ class Migration(migrations.Migration):
                 name="feeds_post_unique_source_guid_when_guid_present",
             ),
         ),
-        migrations.AddConstraint(
+        AddConstraintIfMissing(
             model_name="source",
             constraint=models.UniqueConstraint(
                 fields=("feed_url",), name="feeds_source_unique_feed_url"
             ),
         ),
-        migrations.AddConstraint(
+        AddConstraintIfMissing(
             model_name="subscription",
             constraint=models.UniqueConstraint(
                 condition=models.Q(("source__isnull", False)),

--- a/feeds/migrations/0017_add_integrity_constraints.py
+++ b/feeds/migrations/0017_add_integrity_constraints.py
@@ -2,6 +2,8 @@
 
 from django.db import migrations, models
 
+from ._legacy_duplicate_preflight import preflight_legacy_duplicates
+
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -9,6 +11,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(
+            preflight_legacy_duplicates,
+            migrations.RunPython.noop,
+        ),
         migrations.AddConstraint(
             model_name="post",
             constraint=models.UniqueConstraint(

--- a/feeds/migrations/0018_mysql_compatible_unique_constraints.py
+++ b/feeds/migrations/0018_mysql_compatible_unique_constraints.py
@@ -5,55 +5,8 @@ import hashlib
 
 from django.db import migrations, models
 
+from ._idempotent_operations import AddConstraintIfMissing, AddFieldIfMissing
 from ._legacy_duplicate_preflight import preflight_legacy_duplicates
-
-
-def _column_exists(schema_editor, table_name, column_name):
-    with schema_editor.connection.cursor() as cursor:
-        columns = schema_editor.connection.introspection.get_table_description(
-            cursor, table_name
-        )
-    return any(column.name == column_name for column in columns)
-
-
-def _constraint_exists(schema_editor, table_name, constraint_name):
-    with schema_editor.connection.cursor() as cursor:
-        constraints = schema_editor.connection.introspection.get_constraints(
-            cursor, table_name
-        )
-    return constraint_name in constraints
-
-
-class AddFieldIfMissing(migrations.AddField):
-    """Make retrying a partially applied non-transactional migration safe."""
-
-    def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        model = to_state.apps.get_model(app_label, self.model_name)
-        if not _column_exists(schema_editor, model._meta.db_table, self.name):
-            super().database_forwards(app_label, schema_editor, from_state, to_state)
-
-    def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        model = from_state.apps.get_model(app_label, self.model_name)
-        if _column_exists(schema_editor, model._meta.db_table, self.name):
-            super().database_backwards(app_label, schema_editor, from_state, to_state)
-
-
-class AddConstraintIfMissing(migrations.AddConstraint):
-    """Skip a constraint already created by an interrupted MySQL migration."""
-
-    def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        model = to_state.apps.get_model(app_label, self.model_name)
-        if not _constraint_exists(
-            schema_editor, model._meta.db_table, self.constraint.name
-        ):
-            super().database_forwards(app_label, schema_editor, from_state, to_state)
-
-    def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        model = from_state.apps.get_model(app_label, self.model_name)
-        if _constraint_exists(
-            schema_editor, model._meta.db_table, self.constraint.name
-        ):
-            super().database_backwards(app_label, schema_editor, from_state, to_state)
 
 
 def _digest(guid: str) -> str:
@@ -61,16 +14,19 @@ def _digest(guid: str) -> str:
 
 
 def forwards_fill_guid_digest(apps, schema_editor):
+    database_alias = schema_editor.connection.alias
     Post = apps.get_model("feeds", "Post")
-    for pk, guid in Post.objects.values_list("id", "guid").iterator(chunk_size=500):
+    posts = Post.objects.using(database_alias)
+    for pk, guid in posts.values_list("id", "guid").iterator(chunk_size=500):
         if guid is None:
             continue
-        Post.objects.filter(pk=pk).update(guid_digest=_digest(guid))
+        posts.filter(pk=pk).update(guid_digest=_digest(guid))
 
 
 def backwards_clear_guid_digest(apps, schema_editor):
+    database_alias = schema_editor.connection.alias
     Post = apps.get_model("feeds", "Post")
-    Post.objects.update(guid_digest=None)
+    Post.objects.using(database_alias).update(guid_digest=None)
 
 
 class Migration(migrations.Migration):

--- a/feeds/migrations/0018_mysql_compatible_unique_constraints.py
+++ b/feeds/migrations/0018_mysql_compatible_unique_constraints.py
@@ -3,7 +3,7 @@
 
 import hashlib
 
-from django.db import migrations, models
+from django.db import migrations, models, router
 
 from ._idempotent_operations import AddConstraintIfMissing, AddFieldIfMissing
 from ._legacy_duplicate_preflight import preflight_legacy_duplicates
@@ -16,6 +16,8 @@ def _digest(guid: str) -> str:
 def forwards_fill_guid_digest(apps, schema_editor):
     database_alias = schema_editor.connection.alias
     Post = apps.get_model("feeds", "Post")
+    if not router.allow_migrate_model(database_alias, Post):
+        return
     posts = Post.objects.using(database_alias)
     for pk, guid in posts.values_list("id", "guid").iterator(chunk_size=500):
         if guid is None:
@@ -26,6 +28,8 @@ def forwards_fill_guid_digest(apps, schema_editor):
 def backwards_clear_guid_digest(apps, schema_editor):
     database_alias = schema_editor.connection.alias
     Post = apps.get_model("feeds", "Post")
+    if not router.allow_migrate_model(database_alias, Post):
+        return
     Post.objects.using(database_alias).update(guid_digest=None)
 
 

--- a/feeds/migrations/0018_mysql_compatible_unique_constraints.py
+++ b/feeds/migrations/0018_mysql_compatible_unique_constraints.py
@@ -5,6 +5,56 @@ import hashlib
 
 from django.db import migrations, models
 
+from ._legacy_duplicate_preflight import preflight_legacy_duplicates
+
+
+def _column_exists(schema_editor, table_name, column_name):
+    with schema_editor.connection.cursor() as cursor:
+        columns = schema_editor.connection.introspection.get_table_description(
+            cursor, table_name
+        )
+    return any(column.name == column_name for column in columns)
+
+
+def _constraint_exists(schema_editor, table_name, constraint_name):
+    with schema_editor.connection.cursor() as cursor:
+        constraints = schema_editor.connection.introspection.get_constraints(
+            cursor, table_name
+        )
+    return constraint_name in constraints
+
+
+class AddFieldIfMissing(migrations.AddField):
+    """Make retrying a partially applied non-transactional migration safe."""
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if not _column_exists(schema_editor, model._meta.db_table, self.name):
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if _column_exists(schema_editor, model._meta.db_table, self.name):
+            super().database_backwards(app_label, schema_editor, from_state, to_state)
+
+
+class AddConstraintIfMissing(migrations.AddConstraint):
+    """Skip a constraint already created by an interrupted MySQL migration."""
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if not _constraint_exists(
+            schema_editor, model._meta.db_table, self.constraint.name
+        ):
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if _constraint_exists(
+            schema_editor, model._meta.db_table, self.constraint.name
+        ):
+            super().database_backwards(app_label, schema_editor, from_state, to_state)
+
 
 def _digest(guid: str) -> str:
     return hashlib.sha256(guid.encode("utf-8")).hexdigest()
@@ -29,6 +79,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(
+            preflight_legacy_duplicates,
+            migrations.RunPython.noop,
+        ),
         migrations.RemoveConstraint(
             model_name="post",
             name="feeds_post_unique_source_guid_when_guid_present",
@@ -37,7 +91,7 @@ class Migration(migrations.Migration):
             model_name="subscription",
             name="feeds_subscription_unique_user_source_when_source_present",
         ),
-        migrations.AddField(
+        AddFieldIfMissing(
             model_name="post",
             name="guid_digest",
             field=models.CharField(
@@ -45,14 +99,14 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.RunPython(forwards_fill_guid_digest, backwards_clear_guid_digest),
-        migrations.AddConstraint(
+        AddConstraintIfMissing(
             model_name="post",
             constraint=models.UniqueConstraint(
                 fields=("source", "guid_digest"),
                 name="feeds_post_unique_source_guid_when_guid_present",
             ),
         ),
-        migrations.AddConstraint(
+        AddConstraintIfMissing(
             model_name="subscription",
             constraint=models.UniqueConstraint(
                 fields=("user", "source"),

--- a/feeds/migrations/_idempotent_operations.py
+++ b/feeds/migrations/_idempotent_operations.py
@@ -1,0 +1,49 @@
+from django.db import migrations
+
+
+def _column_exists(schema_editor, table_name, column_name):
+    with schema_editor.connection.cursor() as cursor:
+        columns = schema_editor.connection.introspection.get_table_description(
+            cursor, table_name
+        )
+    return any(column.name == column_name for column in columns)
+
+
+def _constraint_exists(schema_editor, table_name, constraint_name):
+    with schema_editor.connection.cursor() as cursor:
+        constraints = schema_editor.connection.introspection.get_constraints(
+            cursor, table_name
+        )
+    return constraint_name in constraints
+
+
+class AddFieldIfMissing(migrations.AddField):
+    """Make retrying a partially applied non-transactional migration safe."""
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if not _column_exists(schema_editor, model._meta.db_table, self.name):
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if _column_exists(schema_editor, model._meta.db_table, self.name):
+            super().database_backwards(app_label, schema_editor, from_state, to_state)
+
+
+class AddConstraintIfMissing(migrations.AddConstraint):
+    """Skip a constraint already created by an interrupted migration."""
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if not _constraint_exists(
+            schema_editor, model._meta.db_table, self.constraint.name
+        ):
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if _constraint_exists(
+            schema_editor, model._meta.db_table, self.constraint.name
+        ):
+            super().database_backwards(app_label, schema_editor, from_state, to_state)

--- a/feeds/migrations/_idempotent_operations.py
+++ b/feeds/migrations/_idempotent_operations.py
@@ -22,12 +22,16 @@ class AddFieldIfMissing(migrations.AddField):
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.model_name)
-        if not _column_exists(schema_editor, model._meta.db_table, self.name):
+        if self.allow_migrate_model(schema_editor.connection.alias, model) and not (
+            _column_exists(schema_editor, model._meta.db_table, self.name)
+        ):
             super().database_forwards(app_label, schema_editor, from_state, to_state)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         model = from_state.apps.get_model(app_label, self.model_name)
-        if _column_exists(schema_editor, model._meta.db_table, self.name):
+        if self.allow_migrate_model(
+            schema_editor.connection.alias, model
+        ) and _column_exists(schema_editor, model._meta.db_table, self.name):
             super().database_backwards(app_label, schema_editor, from_state, to_state)
 
 
@@ -36,14 +40,18 @@ class AddConstraintIfMissing(migrations.AddConstraint):
 
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.model_name)
-        if not _constraint_exists(
-            schema_editor, model._meta.db_table, self.constraint.name
+        if self.allow_migrate_model(schema_editor.connection.alias, model) and not (
+            _constraint_exists(
+                schema_editor, model._meta.db_table, self.constraint.name
+            )
         ):
             super().database_forwards(app_label, schema_editor, from_state, to_state)
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
-        model = from_state.apps.get_model(app_label, self.model_name)
-        if _constraint_exists(
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(
+            schema_editor.connection.alias, model
+        ) and _constraint_exists(
             schema_editor, model._meta.db_table, self.constraint.name
         ):
             super().database_backwards(app_label, schema_editor, from_state, to_state)

--- a/feeds/migrations/_legacy_duplicate_preflight.py
+++ b/feeds/migrations/_legacy_duplicate_preflight.py
@@ -1,9 +1,9 @@
 from django.db.models import Count
 
 
-def _duplicate_groups(model, group_fields, **filters):
+def _duplicate_groups(model, group_fields, database_alias, **filters):
     """Return a bounded set of duplicate groups and their row IDs."""
-    rows = model.objects.filter(**filters)
+    rows = model.objects.using(database_alias).filter(**filters)
     groups = (
         rows.values(*group_fields)
         .annotate(duplicate_count=Count("pk"))
@@ -27,13 +27,14 @@ def _format_examples(examples, id_label):
 
 def preflight_legacy_duplicates(apps, schema_editor):
     """Stop before adding constraints when legacy-valid duplicates exist."""
+    database_alias = schema_editor.connection.alias
     Source = apps.get_model("feeds", "Source")
     Post = apps.get_model("feeds", "Post")
     Subscription = apps.get_model("feeds", "Subscription")
 
     problems = []
 
-    group_count, examples = _duplicate_groups(Source, ("feed_url",))
+    group_count, examples = _duplicate_groups(Source, ("feed_url",), database_alias)
     if group_count:
         problems.append(
             "Duplicate Source.feed_url values "
@@ -48,6 +49,7 @@ def preflight_legacy_duplicates(apps, schema_editor):
     group_count, examples = _duplicate_groups(
         Post,
         ("source_id", "guid"),
+        database_alias,
         guid__isnull=False,
     )
     if group_count:
@@ -63,6 +65,7 @@ def preflight_legacy_duplicates(apps, schema_editor):
     group_count, examples = _duplicate_groups(
         Subscription,
         ("user_id", "source_id"),
+        database_alias,
         source_id__isnull=False,
     )
     if group_count:

--- a/feeds/migrations/_legacy_duplicate_preflight.py
+++ b/feeds/migrations/_legacy_duplicate_preflight.py
@@ -1,3 +1,4 @@
+from django.db import router
 from django.db.models import Count
 
 
@@ -34,49 +35,52 @@ def preflight_legacy_duplicates(apps, schema_editor):
 
     problems = []
 
-    group_count, examples = _duplicate_groups(Source, ("feed_url",), database_alias)
-    if group_count:
-        problems.append(
-            "Duplicate Source.feed_url values "
-            f"({group_count} group(s); showing at most 5):\n"
-            f"{_format_examples(examples, 'source_ids')}\n"
-            "  Remediation: choose one canonical Source in each group; move or "
-            "merge related Posts and Subscriptions, resolving any resulting "
-            "duplicate GUID or subscription groups; reconcile polling metadata, "
-            "post indexes, and read state; then delete the redundant Sources."
-        )
+    if router.allow_migrate_model(database_alias, Source):
+        group_count, examples = _duplicate_groups(Source, ("feed_url",), database_alias)
+        if group_count:
+            problems.append(
+                "Duplicate Source.feed_url values "
+                f"({group_count} group(s); showing at most 5):\n"
+                f"{_format_examples(examples, 'source_ids')}\n"
+                "  Remediation: choose one canonical Source in each group; move or "
+                "merge related Posts and Subscriptions, resolving any resulting "
+                "duplicate GUID or subscription groups; reconcile polling metadata, "
+                "post indexes, and read state; then delete the redundant Sources."
+            )
 
-    group_count, examples = _duplicate_groups(
-        Post,
-        ("source_id", "guid"),
-        database_alias,
-        guid__isnull=False,
-    )
-    if group_count:
-        problems.append(
-            "Duplicate Post (source_id, guid) values "
-            f"({group_count} group(s); showing at most 5):\n"
-            f"{_format_examples(examples, 'post_ids')}\n"
-            "  Remediation: choose one canonical Post in each group; move or "
-            "merge every related Enclosure and preserve the intended content, "
-            "index, and read-state semantics; then delete the redundant Posts."
+    if router.allow_migrate_model(database_alias, Post):
+        group_count, examples = _duplicate_groups(
+            Post,
+            ("source_id", "guid"),
+            database_alias,
+            guid__isnull=False,
         )
+        if group_count:
+            problems.append(
+                "Duplicate Post (source_id, guid) values "
+                f"({group_count} group(s); showing at most 5):\n"
+                f"{_format_examples(examples, 'post_ids')}\n"
+                "  Remediation: choose one canonical Post in each group; move or "
+                "merge every related Enclosure and preserve the intended content, "
+                "index, and read-state semantics; then delete the redundant Posts."
+            )
 
-    group_count, examples = _duplicate_groups(
-        Subscription,
-        ("user_id", "source_id"),
-        database_alias,
-        source_id__isnull=False,
-    )
-    if group_count:
-        problems.append(
-            "Duplicate Subscription (user_id, source_id) values "
-            f"({group_count} group(s); showing at most 5):\n"
-            f"{_format_examples(examples, 'subscription_ids')}\n"
-            "  Remediation: choose one canonical Subscription in each group and "
-            "reconcile last_read, name, parent, and is_river before deleting the "
-            "redundant Subscriptions."
+    if router.allow_migrate_model(database_alias, Subscription):
+        group_count, examples = _duplicate_groups(
+            Subscription,
+            ("user_id", "source_id"),
+            database_alias,
+            source_id__isnull=False,
         )
+        if group_count:
+            problems.append(
+                "Duplicate Subscription (user_id, source_id) values "
+                f"({group_count} group(s); showing at most 5):\n"
+                f"{_format_examples(examples, 'subscription_ids')}\n"
+                "  Remediation: choose one canonical Subscription in each group and "
+                "reconcile last_read, name, parent, and is_river before deleting the "
+                "redundant Subscriptions."
+            )
 
     if problems:
         raise RuntimeError(

--- a/feeds/migrations/_legacy_duplicate_preflight.py
+++ b/feeds/migrations/_legacy_duplicate_preflight.py
@@ -1,0 +1,86 @@
+from django.db.models import Count
+
+
+def _duplicate_groups(model, group_fields, **filters):
+    """Return a bounded set of duplicate groups and their row IDs."""
+    rows = model.objects.filter(**filters)
+    groups = (
+        rows.values(*group_fields)
+        .annotate(duplicate_count=Count("pk"))
+        .filter(duplicate_count__gt=1)
+        .order_by(*group_fields)
+    )
+    group_count = groups.count()
+    examples = []
+    for group in groups[:5]:
+        lookup = {field: group[field] for field in group_fields}
+        row_ids = list(
+            rows.filter(**lookup).order_by("pk").values_list("pk", flat=True)[:10]
+        )
+        examples.append(row_ids)
+    return group_count, examples
+
+
+def _format_examples(examples, id_label):
+    return "\n".join(f"  - {id_label}={row_ids}" for row_ids in examples)
+
+
+def preflight_legacy_duplicates(apps, schema_editor):
+    """Stop before adding constraints when legacy-valid duplicates exist."""
+    Source = apps.get_model("feeds", "Source")
+    Post = apps.get_model("feeds", "Post")
+    Subscription = apps.get_model("feeds", "Subscription")
+
+    problems = []
+
+    group_count, examples = _duplicate_groups(Source, ("feed_url",))
+    if group_count:
+        problems.append(
+            "Duplicate Source.feed_url values "
+            f"({group_count} group(s); showing at most 5):\n"
+            f"{_format_examples(examples, 'source_ids')}\n"
+            "  Remediation: choose one canonical Source in each group; move or "
+            "merge related Posts and Subscriptions, resolving any resulting "
+            "duplicate GUID or subscription groups; reconcile polling metadata, "
+            "post indexes, and read state; then delete the redundant Sources."
+        )
+
+    group_count, examples = _duplicate_groups(
+        Post,
+        ("source_id", "guid"),
+        guid__isnull=False,
+    )
+    if group_count:
+        problems.append(
+            "Duplicate Post (source_id, guid) values "
+            f"({group_count} group(s); showing at most 5):\n"
+            f"{_format_examples(examples, 'post_ids')}\n"
+            "  Remediation: choose one canonical Post in each group; move or "
+            "merge every related Enclosure and preserve the intended content, "
+            "index, and read-state semantics; then delete the redundant Posts."
+        )
+
+    group_count, examples = _duplicate_groups(
+        Subscription,
+        ("user_id", "source_id"),
+        source_id__isnull=False,
+    )
+    if group_count:
+        problems.append(
+            "Duplicate Subscription (user_id, source_id) values "
+            f"({group_count} group(s); showing at most 5):\n"
+            f"{_format_examples(examples, 'subscription_ids')}\n"
+            "  Remediation: choose one canonical Subscription in each group and "
+            "reconcile last_read, name, parent, and is_river before deleting the "
+            "redundant Subscriptions."
+        )
+
+    if problems:
+        raise RuntimeError(
+            "Cannot add django-feed-reader integrity constraints because legacy "
+            "duplicate rows exist. No later operations from this migration were "
+            "applied. Resolve every group below, back up the database, and rerun "
+            "migrate. Only affected row IDs are logged; feed URLs, GUIDs, user "
+            "IDs, and other potentially private values are omitted.\n\n"
+            + "\n\n".join(problems)
+        )

--- a/feeds/tests/test_migrations.py
+++ b/feeds/tests/test_migrations.py
@@ -2,7 +2,7 @@ import hashlib
 from unittest import skipUnless
 
 from django.conf import settings
-from django.db import connection, models
+from django.db import connection, connections, models
 from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.recorder import MigrationRecorder
 from django.test import TransactionTestCase
@@ -173,6 +173,93 @@ class LegacyDuplicatePreflightMigrationTests(TransactionTestCase):
             hashlib.sha256(b"unique-guid").hexdigest(),
         )
 
+    def test_0017_retry_accepts_existing_source_constraint(self):
+        Source = self.legacy_apps.get_model("feeds", "Source")
+        Source.objects.create(name="unique", feed_url="https://example.com/feed")
+        source_constraint = models.UniqueConstraint(
+            fields=("feed_url",),
+            name="feeds_source_unique_feed_url",
+        )
+        with connection.schema_editor() as schema_editor:
+            schema_editor.add_constraint(Source, source_constraint)
+
+        MigrationExecutor(connection).migrate([self.migrate_to])
+
+        self.assertTrue(
+            MigrationRecorder(connection)
+            .migration_qs.filter(app="feeds", name=self.migrate_to[1])
+            .exists()
+        )
+        self.assertIn("feeds_source_unique_feed_url", self._constraints("feeds_source"))
+
+
+class NonDefaultDatabaseMigrationTests(TransactionTestCase):
+    databases = {"default", "other"}
+    database_alias = "other"
+    migrate_from = ("feeds", "0016_source_due_poll_timezone_aware_default")
+    migrate_to = ("feeds", "0017_add_integrity_constraints")
+    migrate_latest = ("feeds", "0019_performance_indexes")
+
+    def setUp(self):
+        super().setUp()
+        self.database = connections[self.database_alias]
+        executor = MigrationExecutor(self.database)
+        executor.migrate([self.migrate_from])
+        self.legacy_apps = executor.loader.project_state([self.migrate_from]).apps
+        self.addCleanup(self._restore_latest_schema)
+
+    def _restore_latest_schema(self):
+        self.legacy_apps.get_model("feeds", "Source").objects.using(
+            self.database_alias
+        ).all().delete()
+        MigrationExecutor(self.database).migrate([self.migrate_latest])
+
+    def test_preflight_inspects_the_selected_database(self):
+        Source = self.legacy_apps.get_model("feeds", "Source")
+        duplicate_url = "https://example.com/duplicate"
+        Source.objects.using(self.database_alias).create(
+            name="one", feed_url=duplicate_url
+        )
+        Source.objects.using(self.database_alias).create(
+            name="two", feed_url=duplicate_url
+        )
+
+        with self.assertRaises(RuntimeError) as raised:
+            MigrationExecutor(self.database).migrate([self.migrate_to])
+
+        self.assertIn("Duplicate Source.feed_url values", str(raised.exception))
+        self.assertFalse(
+            MigrationRecorder(self.database)
+            .migration_qs.filter(app="feeds", name=self.migrate_to[1])
+            .exists()
+        )
+
+    def test_guid_digest_backfill_uses_the_selected_database(self):
+        Source = self.legacy_apps.get_model("feeds", "Source")
+        Post = self.legacy_apps.get_model("feeds", "Post")
+        source = Source.objects.using(self.database_alias).create(
+            name="unique", feed_url="https://example.com/unique"
+        )
+        post = Post.objects.using(self.database_alias).create(
+            source=source,
+            title="Unique post",
+            body="body",
+            created=timezone.now(),
+            guid="other-database-guid",
+            index=1,
+        )
+
+        executor = MigrationExecutor(self.database)
+        executor.migrate([self.migrate_latest])
+        LatestPost = executor.loader.project_state(
+            [self.migrate_latest]
+        ).apps.get_model("feeds", "Post")
+
+        self.assertEqual(
+            LatestPost.objects.using(self.database_alias).get(pk=post.pk).guid_digest,
+            hashlib.sha256(b"other-database-guid").hexdigest(),
+        )
+
 
 @skipUnless(connection.vendor == "mysql", "MySQL-specific migration recovery")
 class MySQLPublishedMigrationRecoveryTests(TransactionTestCase):
@@ -202,6 +289,12 @@ class MySQLPublishedMigrationRecoveryTests(TransactionTestCase):
         return {column.name for column in columns}
 
     def _mark_published_0017_applied(self):
+        self._add_source_constraint()
+        MigrationRecorder(connection).record_applied(
+            "feeds", "0017_add_integrity_constraints"
+        )
+
+    def _add_source_constraint(self):
         Source = self.legacy_apps.get_model("feeds", "Source")
         source_constraint = models.UniqueConstraint(
             fields=("feed_url",),
@@ -209,9 +302,6 @@ class MySQLPublishedMigrationRecoveryTests(TransactionTestCase):
         )
         with connection.schema_editor() as schema_editor:
             schema_editor.add_constraint(Source, source_constraint)
-        MigrationRecorder(connection).record_applied(
-            "feeds", "0017_add_integrity_constraints"
-        )
 
     def _create_source_and_user(self):
         Source = self.legacy_apps.get_model("feeds", "Source")
@@ -254,6 +344,21 @@ class MySQLPublishedMigrationRecoveryTests(TransactionTestCase):
         )
         self.assertEqual(Post.objects.count(), 2)
         self.assertEqual(Subscription.objects.count(), 2)
+
+    def test_0017_retry_accepts_source_constraint_without_migration_record(self):
+        self._create_source_and_user()
+        self._add_source_constraint()
+
+        MigrationExecutor(connection).migrate(
+            [("feeds", "0017_add_integrity_constraints")]
+        )
+
+        self.assertTrue(
+            MigrationRecorder(connection)
+            .migration_qs.filter(app="feeds", name="0017_add_integrity_constraints")
+            .exists()
+        )
+        self.assertIn("feeds_source_unique_feed_url", self._constraints("feeds_source"))
 
     def test_0018_retry_accepts_partially_applied_mysql_schema(self):
         Post = self.legacy_apps.get_model("feeds", "Post")

--- a/feeds/tests/test_migrations.py
+++ b/feeds/tests/test_migrations.py
@@ -1,0 +1,312 @@
+import hashlib
+from unittest import skipUnless
+
+from django.conf import settings
+from django.db import connection, models
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.recorder import MigrationRecorder
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+
+class LegacyDuplicatePreflightMigrationTests(TransactionTestCase):
+    migrate_from = ("feeds", "0016_source_due_poll_timezone_aware_default")
+    migrate_to = ("feeds", "0017_add_integrity_constraints")
+    migrate_latest = ("feeds", "0019_performance_indexes")
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate([self.migrate_from])
+        self.legacy_apps = executor.loader.project_state([self.migrate_from]).apps
+        self.addCleanup(self._restore_latest_schema)
+
+    def _restore_latest_schema(self):
+        # Remove test rows through the historical model before constraints are added.
+        self.legacy_apps.get_model("feeds", "Source").objects.all().delete()
+        MigrationExecutor(connection).migrate([self.migrate_latest])
+
+    def _constraints(self, table_name):
+        with connection.cursor() as cursor:
+            return connection.introspection.get_constraints(cursor, table_name)
+
+    def _create_legacy_duplicates(self):
+        Source = self.legacy_apps.get_model("feeds", "Source")
+        Post = self.legacy_apps.get_model("feeds", "Post")
+        Enclosure = self.legacy_apps.get_model("feeds", "Enclosure")
+        Subscription = self.legacy_apps.get_model("feeds", "Subscription")
+        user_app, user_model = settings.AUTH_USER_MODEL.split(".", 1)
+        User = self.legacy_apps.get_model(user_app, user_model)
+
+        duplicate_url = "https://private.example/feed?token=do-not-log"
+        source = Source.objects.create(name="canonical", feed_url=duplicate_url)
+        duplicate_source = Source.objects.create(
+            name="duplicate", feed_url=duplicate_url
+        )
+
+        post_defaults = {
+            "source": source,
+            "title": "Legacy post",
+            "body": "body",
+            "created": timezone.now(),
+            "guid": "private-legacy-guid",
+        }
+        post = Post.objects.create(index=1, **post_defaults)
+        duplicate_post = Post.objects.create(index=2, **post_defaults)
+        Enclosure.objects.create(
+            post=post,
+            href="https://example.com/one.mp3",
+            type="audio/mpeg",
+        )
+        Enclosure.objects.create(
+            post=duplicate_post,
+            href="https://example.com/two.mp3",
+            type="audio/mpeg",
+        )
+
+        user = User.objects.create(username="legacy-user")
+        subscription = Subscription.objects.create(
+            user=user,
+            source=source,
+            name="Canonical subscription",
+            last_read=1,
+        )
+        duplicate_subscription = Subscription.objects.create(
+            user=user,
+            source=source,
+            name="Duplicate subscription",
+            last_read=2,
+        )
+        return {
+            "source_ids": [source.pk, duplicate_source.pk],
+            "post_ids": [post.pk, duplicate_post.pk],
+            "subscription_ids": [subscription.pk, duplicate_subscription.pk],
+        }
+
+    def test_preflight_reports_every_duplicate_category_before_constraints(self):
+        duplicate_ids = self._create_legacy_duplicates()
+
+        with self.assertRaises(RuntimeError) as raised:
+            MigrationExecutor(connection).migrate([self.migrate_to])
+
+        message = str(raised.exception)
+        self.assertIn("No later operations from this migration were applied", message)
+        self.assertIn("Duplicate Source.feed_url values (1 group(s)", message)
+        self.assertIn(f"source_ids={duplicate_ids['source_ids']}", message)
+        self.assertIn("Duplicate Post (source_id, guid) values (1 group(s)", message)
+        self.assertIn(f"post_ids={duplicate_ids['post_ids']}", message)
+        self.assertIn(
+            "Duplicate Subscription (user_id, source_id) values (1 group(s)",
+            message,
+        )
+        self.assertIn(
+            f"subscription_ids={duplicate_ids['subscription_ids']}",
+            message,
+        )
+        self.assertNotIn("do-not-log", message)
+        self.assertNotIn("private-legacy-guid", message)
+
+        self.assertEqual(
+            self.legacy_apps.get_model("feeds", "Source").objects.count(), 2
+        )
+        self.assertEqual(self.legacy_apps.get_model("feeds", "Post").objects.count(), 2)
+        self.assertEqual(
+            self.legacy_apps.get_model("feeds", "Enclosure").objects.count(), 2
+        )
+        self.assertEqual(
+            self.legacy_apps.get_model("feeds", "Subscription").objects.count(), 2
+        )
+        self.assertFalse(
+            MigrationRecorder(connection)
+            .migration_qs.filter(app="feeds", name=self.migrate_to[1])
+            .exists()
+        )
+        self.assertNotIn(
+            "feeds_source_unique_feed_url", self._constraints("feeds_source")
+        )
+        self.assertNotIn(
+            "feeds_post_unique_source_guid_when_guid_present",
+            self._constraints("feeds_post"),
+        )
+        self.assertNotIn(
+            "feeds_subscription_unique_user_source_when_source_present",
+            self._constraints("feeds_subscription"),
+        )
+
+    def test_preflight_allows_unique_legacy_rows(self):
+        Source = self.legacy_apps.get_model("feeds", "Source")
+        Post = self.legacy_apps.get_model("feeds", "Post")
+        Subscription = self.legacy_apps.get_model("feeds", "Subscription")
+        user_app, user_model = settings.AUTH_USER_MODEL.split(".", 1)
+        User = self.legacy_apps.get_model(user_app, user_model)
+        source = Source.objects.create(
+            name="unique", feed_url="https://example.com/feed"
+        )
+        post = Post.objects.create(
+            source=source,
+            title="Unique post",
+            body="body",
+            created=timezone.now(),
+            guid="unique-guid",
+            index=1,
+        )
+        user = User.objects.create(username="unique-user")
+        Subscription.objects.create(user=user, source=source, name="Unique")
+
+        executor = MigrationExecutor(connection)
+        executor.migrate([self.migrate_latest])
+        LatestPost = executor.loader.project_state(
+            [self.migrate_latest]
+        ).apps.get_model("feeds", "Post")
+
+        self.assertIn("feeds_source_unique_feed_url", self._constraints("feeds_source"))
+        self.assertIn(
+            "feeds_post_unique_source_guid_when_guid_present",
+            self._constraints("feeds_post"),
+        )
+        self.assertIn(
+            "feeds_subscription_unique_user_source_when_source_present",
+            self._constraints("feeds_subscription"),
+        )
+        self.assertEqual(
+            LatestPost.objects.get(pk=post.pk).guid_digest,
+            hashlib.sha256(b"unique-guid").hexdigest(),
+        )
+
+
+@skipUnless(connection.vendor == "mysql", "MySQL-specific migration recovery")
+class MySQLPublishedMigrationRecoveryTests(TransactionTestCase):
+    migrate_from = ("feeds", "0016_source_due_poll_timezone_aware_default")
+    migrate_to = ("feeds", "0018_mysql_compatible_unique_constraints")
+    migrate_latest = ("feeds", "0019_performance_indexes")
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate([self.migrate_from])
+        self.legacy_apps = executor.loader.project_state([self.migrate_from]).apps
+        self.target_apps = executor.loader.project_state([self.migrate_to]).apps
+        self.addCleanup(self._rebuild_latest_schema)
+
+    def _rebuild_latest_schema(self):
+        MigrationExecutor(connection).migrate([("feeds", None)])
+        MigrationExecutor(connection).migrate([self.migrate_latest])
+
+    def _constraints(self, table_name):
+        with connection.cursor() as cursor:
+            return connection.introspection.get_constraints(cursor, table_name)
+
+    def _column_names(self, table_name):
+        with connection.cursor() as cursor:
+            columns = connection.introspection.get_table_description(cursor, table_name)
+        return {column.name for column in columns}
+
+    def _mark_published_0017_applied(self):
+        Source = self.legacy_apps.get_model("feeds", "Source")
+        source_constraint = models.UniqueConstraint(
+            fields=("feed_url",),
+            name="feeds_source_unique_feed_url",
+        )
+        with connection.schema_editor() as schema_editor:
+            schema_editor.add_constraint(Source, source_constraint)
+        MigrationRecorder(connection).record_applied(
+            "feeds", "0017_add_integrity_constraints"
+        )
+
+    def _create_source_and_user(self):
+        Source = self.legacy_apps.get_model("feeds", "Source")
+        user_app, user_model = settings.AUTH_USER_MODEL.split(".", 1)
+        User = self.legacy_apps.get_model(user_app, user_model)
+        source = Source.objects.create(
+            name="legacy", feed_url="https://example.com/legacy"
+        )
+        user = User.objects.create(username="mysql-legacy-user")
+        return source, user
+
+    def test_0018_preflights_databases_with_published_0017_recorded(self):
+        Post = self.legacy_apps.get_model("feeds", "Post")
+        Subscription = self.legacy_apps.get_model("feeds", "Subscription")
+        source, user = self._create_source_and_user()
+        post_defaults = {
+            "source": source,
+            "title": "Legacy post",
+            "body": "body",
+            "created": timezone.now(),
+            "guid": "duplicate-guid",
+        }
+        Post.objects.create(index=1, **post_defaults)
+        Post.objects.create(index=2, **post_defaults)
+        Subscription.objects.create(user=user, source=source, name="One")
+        Subscription.objects.create(user=user, source=source, name="Two")
+        self._mark_published_0017_applied()
+
+        with self.assertRaises(RuntimeError) as raised:
+            MigrationExecutor(connection).migrate([self.migrate_to])
+
+        message = str(raised.exception)
+        self.assertIn("Duplicate Post (source_id, guid) values", message)
+        self.assertIn("Duplicate Subscription (user_id, source_id) values", message)
+        self.assertNotIn("guid_digest", self._column_names("feeds_post"))
+        self.assertFalse(
+            MigrationRecorder(connection)
+            .migration_qs.filter(app="feeds", name=self.migrate_to[1])
+            .exists()
+        )
+        self.assertEqual(Post.objects.count(), 2)
+        self.assertEqual(Subscription.objects.count(), 2)
+
+    def test_0018_retry_accepts_partially_applied_mysql_schema(self):
+        Post = self.legacy_apps.get_model("feeds", "Post")
+        Subscription = self.legacy_apps.get_model("feeds", "Subscription")
+        TargetPost = self.target_apps.get_model("feeds", "Post")
+        source, user = self._create_source_and_user()
+        post = Post.objects.create(
+            source=source,
+            title="Legacy post",
+            body="body",
+            created=timezone.now(),
+            guid="unique-guid",
+            index=1,
+        )
+        Subscription.objects.create(user=user, source=source, name="Keep")
+        duplicate_subscription = Subscription.objects.create(
+            user=user, source=source, name="Remove"
+        )
+        self._mark_published_0017_applied()
+
+        guid_digest_field = TargetPost._meta.get_field("guid_digest")
+        post_constraint = next(
+            constraint
+            for constraint in TargetPost._meta.constraints
+            if constraint.name == "feeds_post_unique_source_guid_when_guid_present"
+        )
+        with connection.schema_editor() as schema_editor:
+            schema_editor.add_field(Post, guid_digest_field)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE feeds_post SET guid_digest = %s WHERE id = %s",
+                [hashlib.sha256(post.guid.encode("utf-8")).hexdigest(), post.pk],
+            )
+        with connection.schema_editor() as schema_editor:
+            schema_editor.add_constraint(TargetPost, post_constraint)
+
+        with self.assertRaises(RuntimeError):
+            MigrationExecutor(connection).migrate([self.migrate_to])
+
+        duplicate_subscription.delete()
+        MigrationExecutor(connection).migrate([self.migrate_to])
+
+        self.assertTrue(
+            MigrationRecorder(connection)
+            .migration_qs.filter(app="feeds", name=self.migrate_to[1])
+            .exists()
+        )
+        self.assertIn("guid_digest", self._column_names("feeds_post"))
+        self.assertIn(
+            "feeds_post_unique_source_guid_when_guid_present",
+            self._constraints("feeds_post"),
+        )
+        self.assertIn(
+            "feeds_subscription_unique_user_source_when_source_present",
+            self._constraints("feeds_subscription"),
+        )

--- a/feeds/tests/test_migrations.py
+++ b/feeds/tests/test_migrations.py
@@ -5,8 +5,22 @@ from django.conf import settings
 from django.db import connection, connections, models
 from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.recorder import MigrationRecorder
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, override_settings
 from django.utils import timezone
+
+
+class DenyFeedsOnOtherRouter:
+    def allow_migrate(self, database, app_label, **hints):
+        if database == "other" and app_label == "feeds":
+            return False
+        return None
+
+
+class DenyFeedModelsOnOtherRouter:
+    def allow_migrate(self, database, app_label, model_name=None, **hints):
+        if database == "other" and app_label == "feeds" and model_name is not None:
+            return False
+        return None
 
 
 class LegacyDuplicatePreflightMigrationTests(TransactionTestCase):
@@ -259,6 +273,48 @@ class NonDefaultDatabaseMigrationTests(TransactionTestCase):
             LatestPost.objects.using(self.database_alias).get(pk=post.pk).guid_digest,
             hashlib.sha256(b"other-database-guid").hexdigest(),
         )
+
+
+class RoutedOutDatabaseMigrationTests(TransactionTestCase):
+    databases = {"default", "other"}
+    database_alias = "other"
+    migrate_latest = ("feeds", "0019_performance_indexes")
+
+    def setUp(self):
+        super().setUp()
+        self.database = connections[self.database_alias]
+        MigrationExecutor(self.database).migrate([("feeds", None)])
+        self.addCleanup(self._restore_latest_schema)
+
+    def _restore_latest_schema(self):
+        MigrationRecorder(self.database).migration_qs.filter(app="feeds").delete()
+        MigrationExecutor(self.database).migrate([self.migrate_latest])
+
+    @override_settings(
+        DATABASE_ROUTERS=[
+            "feeds.tests.test_migrations.DenyFeedsOnOtherRouter",
+        ]
+    )
+    def test_routed_out_database_does_not_access_feed_tables(self):
+        MigrationExecutor(self.database).migrate([self.migrate_latest])
+
+        with self.database.cursor() as cursor:
+            table_names = self.database.introspection.table_names(cursor)
+        self.assertNotIn("feeds_source", table_names)
+        self.assertNotIn("feeds_post", table_names)
+
+    @override_settings(
+        DATABASE_ROUTERS=[
+            "feeds.tests.test_migrations.DenyFeedModelsOnOtherRouter",
+        ]
+    )
+    def test_model_routed_out_database_skips_run_python_queries(self):
+        MigrationExecutor(self.database).migrate([self.migrate_latest])
+
+        with self.database.cursor() as cursor:
+            table_names = self.database.introspection.table_names(cursor)
+        self.assertNotIn("feeds_source", table_names)
+        self.assertNotIn("feeds_post", table_names)
 
 
 @skipUnless(connection.vendor == "mysql", "MySQL-specific migration recovery")

--- a/tests/mysql_settings.py
+++ b/tests/mysql_settings.py
@@ -1,5 +1,6 @@
 import os
 
+from . import settings as base_settings
 from .settings import *
 
 DATABASES = {
@@ -11,5 +12,6 @@ DATABASES = {
         "HOST": os.environ.get("MYSQL_HOST", "127.0.0.1"),
         "PORT": os.environ.get("MYSQL_PORT", "3306"),
         "OPTIONS": {"charset": "utf8mb4"},
-    }
+    },
+    "other": base_settings.DATABASES["other"],
 }

--- a/tests/mysql_settings.py
+++ b/tests/mysql_settings.py
@@ -1,0 +1,15 @@
+import os
+
+from .settings import *
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": os.environ.get("MYSQL_DATABASE", "django_feed_reader"),
+        "USER": os.environ.get("MYSQL_USER", "root"),
+        "PASSWORD": os.environ.get("MYSQL_PASSWORD", "root"),
+        "HOST": os.environ.get("MYSQL_HOST", "127.0.0.1"),
+        "PORT": os.environ.get("MYSQL_PORT", "3306"),
+        "OPTIONS": {"charset": "utf8mb4"},
+    }
+}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,7 +12,11 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "test.sqlite3",
-    }
+    },
+    "other": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
 }
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Desired outcome

Prevent legacy-valid duplicate feed data from failing integrity-constraint migrations with an opaque database error or leaving a MySQL installation unable to retry a partially applied migration.

## Motivation

Schemas before `feeds.0017` allowed duplicate source URLs, per-source post GUIDs, and user/source subscriptions. Adding uniqueness constraints without a preflight blocks affected upgrades and can be especially difficult to recover on MySQL, where DDL is non-transactional and published `0017` may already be recorded before `0018` fails.

## Scope

- Run one read-only duplicate preflight before schema operations in both `0017` and `0018`.
- Report every duplicate category together using bounded row-ID examples and actionable, data-preserving remediation guidance.
- Make the `0018` field and constraint additions safe to retry when MySQL already created some schema objects before an interruption.
- Add migration-executor coverage for duplicate and clean upgrades, published-`0017` MySQL state, and partial-`0018` recovery.
- Run the migration suite against MySQL 8 in CI as well as the existing SQLite coverage.

## Non-goals

- Automatically merge or delete legacy rows.
- Choose canonical source, post, or subscription records for downstream installations.
- Change public model fields, related names, utility signatures, or normal runtime behavior.

## Acceptance criteria

- [x] Duplicate source URLs, non-null per-source GUIDs, and non-null user/source subscriptions are detected before constraints are added.
- [x] Affected upgrades stop without changing rows and explain how to preserve posts, subscriptions, enclosures, indexes, and read state during manual remediation.
- [x] Upgrade tests begin at `0016` and cover all three duplicate categories plus a clean migration through `0019`.
- [x] Tests assert row preservation, migration-recorder state, absent constraints, sensitive-value redaction, GUID digest backfill, and final constraints.
- [x] Published MySQL `0017` state and a partially applied non-transactional `0018` retry are represented by backend-specific tests.
- [x] The new MySQL 8 CI job passes on this PR.

## Implementation decisions

- The conflict policy is deliberately non-destructive: migration stops and requires the operator to choose canonical records.
- Diagnostic output contains affected row primary keys only. Feed URLs, GUIDs, user IDs, and grouping values are omitted from logs.
- Both published migrations are updated intentionally. Installations that completed them skip them as usual; installations blocked before a migration was recorded receive the preflight, while `0018` additionally tolerates schema objects left by interrupted MySQL DDL.
- Digest backfill remains repeatable, and conditional field/constraint operations preserve migration state while avoiding duplicate-object errors during retries.

## Validation

- `.venv/bin/pytest --reuse-db feeds/tests/test_migrations.py -q` — 2 passed, 2 MySQL-only skipped locally.
- `.venv/bin/pytest --reuse-db` — 116 passed, 2 MySQL-only skipped locally.
- `.venv/bin/django-admin makemigrations --check --dry-run --settings=tests.settings` — no changes detected.
- Ruff check and format checks — passed.
- `git diff --check` — passed.
- Fresh acceptance verification — no material code or migration-safety defect found; its required MySQL condition subsequently passed in PR CI.
- PR CI — MySQL 8 migration tests, all four Django/Python matrix jobs, and CodeQL passed.

## Migration, data, and rollout notes

This change never mutates duplicate application rows. Operators encountering the preflight should back up the database, inspect the listed row IDs, merge or delete duplicates according to the emitted guidance, and rerun `migrate`.

The local host had no MySQL service, so backend-specific execution was delegated to the added MySQL 8 CI job, which passed. The PR should remain draft until fresh code review is complete.

Closes #47
