### PR TITLE
fix: persist feed poll timestamps

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -307,9 +307,6 @@ Evidence: `AGENTS.md`; `setup.py`; `feeds/models.py`;
 
 ## 10. Suspected defects, contradictions, and coverage gaps
 
-- **GAP-002 — `last_polled` persistence:** `read_feed` assigns `last_polled`, but the
-  final partial save omits that field, so the assignment is not persisted by the
-  observed path.
 - **GAP-003 — Subscription tree integrity:** cross-user parent relationships and
   cycles are not rejected by model validation or database constraints.
 - **GAP-004 — Ignored pagination direction:**

--- a/feeds/tests/test_http.py
+++ b/feeds/tests/test_http.py
@@ -49,6 +49,7 @@ class HTTPStuffTest(BaseTest):
         read_feed(src, output=NullOutput())
         src.refresh_from_db()
 
+        self.assertIsNotNone(src.last_polled)
         self.assertEqual(src.status_code, 200)
         self.assertEqual(src.posts.count(), 1)  # got the one post
         self.assertEqual(src.interval, 60)
@@ -111,6 +112,7 @@ class HTTPStuffTest(BaseTest):
         read_feed(src, output=NullOutput())
         src.refresh_from_db()
 
+        self.assertIsNotNone(src.last_polled)
         self.assertEqual(src.status_code, 0)
         self.assertTrue(src.last_result.startswith("Fetch error:"))
 
@@ -126,6 +128,7 @@ class HTTPStuffTest(BaseTest):
         read_feed(src, output=NullOutput())
         src.refresh_from_db()
 
+        self.assertIsNotNone(src.last_polled)
         self.assertEqual(src.status_code, 400)
         self.assertFalse(src.live)
         self.assertIn("400", src.last_result)

--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -340,6 +340,7 @@ def _read_feed_finalize_interval_and_save(
         update_fields=[
             "due_poll",
             "interval",
+            "last_polled",
             "last_result",
             "last_modified",
             "etag",


### PR DESCRIPTION
## Outcome

`read_feed()` persists the timestamp at which each polling attempt begins. The stored `Source.last_polled` value now survives a database refresh after successful responses, HTTP errors, and network exceptions.

## Motivation

The polling code assigned `last_polled` in memory but omitted it from the final partial save, leaving operators and downstream applications unable to reliably determine whether or when a source was polled.

## Scope

- Include `last_polled` in the existing final `Source.save(update_fields=...)` call.
- Add regression assertions that reload the source from the database for successful, HTTP-error, and network-exception attempts.
- Remove the resolved `last_polled` persistence gap from the current-state specification.

This does not change the timestamp's existing attempt-start semantics, polling schedules, public API, or database schema.

## Acceptance criteria

- [x] `last_polled` is included in the persisted final state.
- [x] Successful, HTTP-error, and network-exception polling attempts persist it.
- [x] Regression tests refresh from the database before asserting the value.

## Validation

- Focused regression tests: 3 passed.
- Full configured suite: 121 passed, 3 skipped.
- `git diff --check`: passed.

## Compatibility and rollout

No migration, data backfill, public API change, security impact, or special rollout is required. Existing rows are populated on their next polling attempt.

Closes #52
