### PR TITLE
fix: validate subscription parent trees

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -240,9 +240,10 @@ Evidence: enclosure synchronization in `feeds/utils_internal.py`;
 - **SUB-006** — Root subscription listing shall order river subscriptions first,
   then by name. Unread listing shall omit read non-river sources and empty folders,
   while retaining river subscriptions.
-- **SUB-007** — Subscription folders are expected to represent a hierarchy for one
-  user, but same-user and acyclic parentage are not enforced. Intended invariants
-  are subject to assumption A-003.
+- **SUB-007** — Subscription parents shall be folders belonging to the same user,
+  and model saves shall reject self-parenting and ancestor cycles. Tree traversal
+  shall terminate defensively when model validation has been bypassed by legacy or
+  external database writes.
 
 Evidence: `feeds/models.py`; `feeds/utils.py`;
 `feeds/tests/test_subscriptions.py`.
@@ -345,21 +346,6 @@ Impact if wrong: whether transient authentication, permission, and rate-limit
 failures permanently stop polling.
 
 Question: Which 4xx responses should disable a source rather than remain retryable?
-
-### A-003 — Subscription tree integrity
-
-Provisional interpretation: folder relationships are intended to form same-user,
-acyclic trees despite the lack of enforcement.
-
-Evidence: per-user traversal helpers and nested-folder tests; no matching model or
-database constraint.
-
-Confidence: high.
-
-Impact if wrong: authorization boundaries, unread aggregation, cascade deletion,
-and traversal termination.
-
-Question: Must a parent belong to the same user, and must cycles be rejected?
 
 ### A-004 — URL safety boundary
 

--- a/feeds/models.py
+++ b/feeds/models.py
@@ -6,8 +6,9 @@ from urllib.parse import urlencode
 
 import django.utils as django_utils
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
-from django.db import models
+from django.db import models, router
 from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -471,6 +472,100 @@ class Subscription(models.Model):
     name = models.CharField(max_length=255)
     """**str** The display name of the subscription - typically should be set to the name of the source where present"""
 
+    def _validate_parent_relationship(self, using=None):
+        database = using or self._state.db or router.db_for_read(
+            type(self), instance=self
+        )
+        if self.parent_id is not None:
+            seen = {self.pk} if self.pk is not None else set()
+            ancestor_id = self.parent_id
+
+            while ancestor_id is not None:
+                if ancestor_id in seen:
+                    raise ValidationError(
+                        {"parent": "A subscription parent cannot create a cycle."}
+                    )
+                seen.add(ancestor_id)
+
+                ancestor = (
+                    type(self).objects.using(database)
+                    .filter(pk=ancestor_id)
+                    .values("parent_id", "source_id", "user_id")
+                    .first()
+                )
+                if ancestor is None:
+                    break
+                if (
+                    self.user_id is not None
+                    and ancestor["user_id"] != self.user_id
+                ):
+                    raise ValidationError(
+                        {
+                            "parent": (
+                                "A subscription parent must belong to the same user."
+                            )
+                        }
+                    )
+                if ancestor["source_id"] is not None:
+                    raise ValidationError(
+                        {"parent": "A subscription parent must be a folder."}
+                    )
+                ancestor_id = ancestor["parent_id"]
+
+        if self.pk is None:
+            return
+
+        children = type(self).objects.using(database).filter(parent_id=self.pk)
+        if self.source_id is not None and children.exists():
+            raise ValidationError(
+                {"source": "A subscription with children must remain a folder."}
+            )
+        has_other_user_children = (
+            self.user_id is not None
+            and children.exclude(user_id=self.user_id).exists()
+        )
+        if has_other_user_children:
+            raise ValidationError(
+                {"user": "A subscription parent must have the same user as its children."}
+            )
+
+    def clean(self):
+        super().clean()
+        self._validate_parent_relationship()
+
+    def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+        relationship_fields = {
+            "parent",
+            "parent_id",
+            "source",
+            "source_id",
+            "user",
+            "user_id",
+        }
+        if update_fields is None or relationship_fields.intersection(update_fields):
+            self._validate_parent_relationship(using=kwargs.get("using"))
+        super().save(*args, **kwargs)
+
+    def _descendants(self, children_by_parent=None):
+        """Yield each descendant once, even if stored parent data has a cycle."""
+        if children_by_parent is None:
+            children_by_parent = _subscription_children_by_parent(self.user_id)
+
+        seen = {self.pk}
+        stack = list(children_by_parent.get(self.pk, []))
+        while stack:
+            sub = stack.pop()
+            if sub.pk in seen:
+                continue
+            seen.add(sub.pk)
+            yield sub
+            stack.extend(children_by_parent.get(sub.pk, []))
+
+    def _tree_members(self, children_by_parent=None):
+        yield self
+        yield from self._descendants(children_by_parent)
+
     @property
     def unread_count(self) -> int:
         """**int** The number of undread posts in teh subscription
@@ -485,12 +580,9 @@ class Subscription(models.Model):
         # One query for the whole user tree instead of one query per folder level.
         by_parent = _subscription_children_by_parent(self.user_id)
         total = 0
-        stack = list(by_parent.get(self.id, []))
-        while stack:
-            sub = stack.pop()
+        for sub in self._descendants(by_parent):
             if sub.source_id:
                 total += sub.source.max_index - sub.last_read
-            stack.extend(by_parent.get(sub.id, []))
         self._unread_count = total
         return self._unread_count
 
@@ -499,16 +591,16 @@ class Subscription(models.Model):
         if children_by_parent is None:
             children_by_parent = _subscription_children_by_parent(self.user_id)
 
-        if self.source:
-            posts = list(
-                Post.objects.filter(Q(source=self.source) & Q(index__gt=self.last_read))
-            )
-            for post in posts:
-                post.from_subscription = self
-                post_list.append(post)
-
-        for child in children_by_parent.get(self.id, []):
-            child._gather_posts(post_list, children_by_parent)
+        for sub in self._tree_members(children_by_parent):
+            if sub.source:
+                posts = list(
+                    Post.objects.filter(
+                        Q(source=sub.source) & Q(index__gt=sub.last_read)
+                    )
+                )
+                for post in posts:
+                    post.from_subscription = sub
+                    post_list.append(post)
 
     def get_unread_posts(self, oldest_first=True):
         """Returns all the unread posts in a subscription"""
@@ -523,11 +615,9 @@ class Subscription(models.Model):
         if children_by_parent is None:
             children_by_parent = _subscription_children_by_parent(self.user_id)
 
-        if self.source:
-            source_list[self.source.id] = self
-
-        for child in children_by_parent.get(self.id, []):
-            child._gather_sources(source_list, children_by_parent)
+        for sub in self._tree_members(children_by_parent):
+            if sub.source:
+                source_list[sub.source.id] = sub
 
     def get_paginated_posts(
         self, page: int, oldest_first: bool = True, posts_per_page: int = 20
@@ -573,14 +663,11 @@ class Subscription(models.Model):
             self.save(update_fields=["last_read"])
             return
         by_parent = _subscription_children_by_parent(self.user_id)
-        stack = list(by_parent.get(self.id, []))
         to_update = []
-        while stack:
-            sub = stack.pop()
+        for sub in self._descendants(by_parent):
             if sub.source_id and sub.last_read != sub.source.max_index:
                 sub.last_read = sub.source.max_index
                 to_update.append(sub)
-            stack.extend(by_parent.get(sub.id, []))
         if to_update:
             Subscription.objects.bulk_update(to_update, ["last_read"])
 

--- a/feeds/models.py
+++ b/feeds/models.py
@@ -473,7 +473,7 @@ class Subscription(models.Model):
     """**str** The display name of the subscription - typically should be set to the name of the source where present"""
 
     def _validate_parent_relationship(self, using=None):
-        database = using or self._state.db or router.db_for_read(
+        database = using or self._state.db or router.db_for_write(
             type(self), instance=self
         )
         if self.parent_id is not None:
@@ -533,8 +533,15 @@ class Subscription(models.Model):
         super().clean()
         self._validate_parent_relationship()
 
-    def save(self, *args, **kwargs):
-        update_fields = kwargs.get("update_fields")
+    def save(
+        self,
+        force_insert=False,
+        force_update=False,
+        using=None,
+        update_fields=None,
+    ):
+        if update_fields is not None:
+            update_fields = frozenset(update_fields)
         relationship_fields = {
             "parent",
             "parent_id",
@@ -544,8 +551,14 @@ class Subscription(models.Model):
             "user_id",
         }
         if update_fields is None or relationship_fields.intersection(update_fields):
-            self._validate_parent_relationship(using=kwargs.get("using"))
-        super().save(*args, **kwargs)
+            database = using or router.db_for_write(type(self), instance=self)
+            self._validate_parent_relationship(using=database)
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )
 
     def _descendants(self, children_by_parent=None):
         """Yield each descendant once, even if stored parent data has a cycle."""

--- a/feeds/tests/test_subscriptions.py
+++ b/feeds/tests/test_subscriptions.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import requests_mock
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 from django.utils import timezone
 
 from feeds.models import Post, Source, Subscription
@@ -15,6 +16,18 @@ from feeds.utils import (
 from .base import BaseTest, NullOutput
 
 User = get_user_model()
+
+
+class SubscriptionReadDefaultWriteOtherRouter:
+    def db_for_read(self, model, **hints):
+        if model is Subscription:
+            return "default"
+        return None
+
+    def db_for_write(self, model, **hints):
+        if model is Subscription:
+            return "other"
+        return None
 
 
 def feed_url_for(label):
@@ -693,3 +706,73 @@ class MalformedSubscriptionTraversalTest(BaseTest):
             get_unread_subscription_list_for_user(self.user),
             [valid_root],
         )
+
+
+class SubscriptionSaveCompatibilityTest(BaseTest):
+    databases = {"default", "other"}
+
+    def _other_database_users(self):
+        parent_owner = User.objects.db_manager("other").create_user(
+            username="other-parent-owner"
+        )
+        child_owner = User.objects.db_manager("other").create_user(
+            username="other-child-owner"
+        )
+        return parent_owner, child_owner
+
+    @override_settings(DATABASE_ROUTERS=[SubscriptionReadDefaultWriteOtherRouter()])
+    def test_save_validates_on_routed_write_database(self):
+        parent_owner, child_owner = self._other_database_users()
+        parent = Subscription.objects.using("other").create(
+            user_id=parent_owner.pk,
+            source=None,
+            name="Other database parent",
+        )
+        child = Subscription(
+            user_id=child_owner.pk,
+            source=None,
+            name="Other database child",
+            parent_id=parent.pk,
+        )
+
+        with self.assertRaises(ValidationError):
+            child.save()
+
+        self.assertFalse(
+            Subscription.objects.using("other").filter(name=child.name).exists()
+        )
+
+    def test_save_honors_positional_database_argument_during_validation(self):
+        parent_owner, child_owner = self._other_database_users()
+        parent = Subscription.objects.using("other").create(
+            user_id=parent_owner.pk,
+            source=None,
+            name="Positional database parent",
+        )
+        child = Subscription(
+            user_id=child_owner.pk,
+            source=None,
+            name="Positional database child",
+            parent_id=parent.pk,
+        )
+
+        with self.assertRaises(ValidationError):
+            child.save(False, False, "other")
+
+        self.assertFalse(
+            Subscription.objects.using("other").filter(name=child.name).exists()
+        )
+
+    def test_save_preserves_generator_update_fields(self):
+        user = User.objects.create_user(username="generator-update-fields")
+        subscription = Subscription.objects.create(
+            user=user,
+            source=None,
+            name="Before",
+        )
+        subscription.name = "After"
+
+        subscription.save(update_fields=(field for field in ["name"]))
+
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.name, "After")

--- a/feeds/tests/test_subscriptions.py
+++ b/feeds/tests/test_subscriptions.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import requests_mock
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from feeds.models import Post, Source, Subscription
@@ -482,3 +483,213 @@ class SubscriptionsTest(BaseTest):
         self.assertEqual(len(posts_newest), 1)
         self.assertEqual(len(posts_oldest), 1)
         self.assertEqual(posts_newest[0].id, posts_oldest[0].id)
+
+
+class SubscriptionParentValidationTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(username="subscription-owner")
+        self.other_user = User.objects.create_user(username="other-owner")
+
+    def test_subscription_cannot_be_its_own_parent(self):
+        folder = Subscription.objects.create(
+            user=self.user, source=None, name="Folder"
+        )
+
+        folder.parent = folder
+
+        with self.assertRaises(ValidationError):
+            folder.save()
+
+    def test_subscription_parent_cannot_create_ancestor_cycle(self):
+        parent = Subscription.objects.create(
+            user=self.user, source=None, name="Parent"
+        )
+        child = Subscription.objects.create(
+            user=self.user, source=None, name="Child", parent=parent
+        )
+
+        parent.parent = child
+
+        with self.assertRaises(ValidationError):
+            parent.save()
+
+    def test_subscription_parent_must_belong_to_same_user(self):
+        other_users_folder = Subscription.objects.create(
+            user=self.other_user, source=None, name="Other user's folder"
+        )
+
+        with self.assertRaises(ValidationError):
+            Subscription.objects.create(
+                user=self.user,
+                source=None,
+                name="Cross-user child",
+                parent=other_users_folder,
+            )
+
+    def test_subscription_parent_must_be_a_folder(self):
+        source = Source.objects.create(
+            name="Parent feed", feed_url=feed_url_for("non-folder-parent")
+        )
+        feed_subscription = Subscription.objects.create(
+            user=self.user, source=source, name="Feed"
+        )
+
+        with self.assertRaises(ValidationError):
+            Subscription.objects.create(
+                user=self.user,
+                source=None,
+                name="Child folder",
+                parent=feed_subscription,
+            )
+
+    def test_parent_folder_cannot_be_changed_to_feed(self):
+        source = Source.objects.create(
+            name="Replacement feed",
+            feed_url=feed_url_for("folder-changed-to-feed"),
+        )
+        parent = Subscription.objects.create(
+            user=self.user, source=None, name="Parent"
+        )
+        Subscription.objects.create(
+            user=self.user, source=None, name="Child", parent=parent
+        )
+
+        parent.source = source
+
+        with self.assertRaises(ValidationError):
+            parent.save(update_fields=["source"])
+
+    def test_parent_folder_cannot_be_changed_to_another_user(self):
+        parent = Subscription.objects.create(
+            user=self.user, source=None, name="Parent"
+        )
+        Subscription.objects.create(
+            user=self.user, source=None, name="Child", parent=parent
+        )
+
+        parent.user = self.other_user
+
+        with self.assertRaises(ValidationError):
+            parent.save(update_fields=["user"])
+
+    def test_valid_nested_subscription_tree(self):
+        source = Source.objects.create(
+            name="Nested feed",
+            feed_url=feed_url_for("valid-nested-tree"),
+            max_index=1,
+        )
+        root = Subscription.objects.create(
+            user=self.user, source=None, name="Root"
+        )
+        child = Subscription.objects.create(
+            user=self.user, source=None, name="Child", parent=root
+        )
+        Subscription.objects.create(
+            user=self.user, source=source, name="Feed", parent=child
+        )
+
+        self.assertEqual(root.unread_count, 1)
+        self.assertEqual(get_unread_subscription_list_for_user(self.user), [root])
+
+
+class MalformedSubscriptionTraversalTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(username="legacy-owner")
+
+    def test_tree_traversals_terminate_for_legacy_cycle(self):
+        source = Source.objects.create(
+            name="Legacy feed",
+            feed_url=feed_url_for("legacy-cycle"),
+        )
+        post = Post.objects.create(
+            source=source,
+            title="Unread post",
+            body="",
+            created=timezone.now(),
+            index=None,
+        )
+        first = Subscription.objects.create(
+            user=self.user, source=None, name="First"
+        )
+        second = Subscription.objects.create(
+            user=self.user, source=None, name="Second", parent=first
+        )
+        feed = Subscription.objects.create(
+            user=self.user, source=source, name="Feed", parent=second
+        )
+        Subscription.objects.filter(pk=first.pk).update(parent=second)
+        first.refresh_from_db()
+
+        self.assertEqual(first.unread_count, 1)
+        self.assertEqual(first.get_unread_posts(), [post])
+        posts, paginator = first.get_paginated_posts(1)
+        self.assertEqual(list(posts), [post])
+        self.assertEqual(paginator.count, 1)
+
+        first.mark_read()
+
+        feed.refresh_from_db()
+        self.assertEqual(feed.last_read, source.max_index)
+
+    def test_unread_list_ignores_malformed_legacy_relationships(self):
+        other_user = User.objects.create_user(username="other-legacy-owner")
+        valid_source = Source.objects.create(
+            name="Valid feed",
+            feed_url=feed_url_for("valid-legacy-list-root"),
+            max_index=1,
+        )
+        invalid_parent_source = Source.objects.create(
+            name="Invalid parent feed",
+            feed_url=feed_url_for("invalid-legacy-list-parent"),
+        )
+        valid_root = Subscription.objects.create(
+            user=self.user, source=None, name="Valid root"
+        )
+        Subscription.objects.create(
+            user=self.user,
+            source=valid_source,
+            name="Valid feed",
+            parent=valid_root,
+        )
+        other_users_folder = Subscription.objects.create(
+            user=other_user, source=None, name="Other user's folder"
+        )
+        cross_user_folder = Subscription.objects.create(
+            user=self.user, source=None, name="Cross-user folder"
+        )
+        non_folder_parent = Subscription.objects.create(
+            user=self.user,
+            source=invalid_parent_source,
+            name="Non-folder parent",
+        )
+        child_of_non_folder = Subscription.objects.create(
+            user=self.user, source=None, name="Child of non-folder"
+        )
+        first_cycle_folder = Subscription.objects.create(
+            user=self.user, source=None, name="First cycle folder"
+        )
+        second_cycle_folder = Subscription.objects.create(
+            user=self.user,
+            source=None,
+            name="Second cycle folder",
+            parent=first_cycle_folder,
+        )
+
+        # QuerySet.update deliberately bypasses model validation to represent
+        # malformed legacy or externally written rows.
+        Subscription.objects.filter(pk=cross_user_folder.pk).update(
+            parent=other_users_folder
+        )
+        Subscription.objects.filter(pk=child_of_non_folder.pk).update(
+            parent=non_folder_parent
+        )
+        Subscription.objects.filter(pk=first_cycle_folder.pk).update(
+            parent=second_cycle_folder
+        )
+
+        self.assertEqual(
+            get_unread_subscription_list_for_user(self.user),
+            [valid_root],
+        )

--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -511,6 +511,7 @@ def get_unread_subscription_list_for_user(user) -> List[Subscription]:
                 grp._unread_count += sub.unread_count
 
     while len(groups.keys()) > 0:
+        made_progress = False
         for key in list(groups.keys()):
             folder = groups[key]
             found = False
@@ -524,9 +525,15 @@ def get_unread_subscription_list_for_user(user) -> List[Subscription]:
             if not found:
                 # This folder does not have any children
                 if folder.parent_id is not None:
-                    parent = groups[folder.parent_id]
-                    parent._unread_count += folder._unread_count
+                    parent = groups.get(folder.parent_id)
+                    if parent is not None:
+                        parent._unread_count += folder._unread_count
                 groups.pop(folder.id)
+                made_progress = True
+        if not made_progress:
+            # Malformed legacy parent cycles have no leaf to reduce. They are not
+            # root subscriptions, so leave them out rather than looping forever.
+            break
 
     return [
         s for s in subs_list if s.unread_count > 0 or s.is_river


### PR DESCRIPTION
## Desired outcome

Ensure `Subscription.parent` relationships form same-user, acyclic folder trees so invalid hierarchy data cannot hang subscription traversal or cross user boundaries.

Closes #48

## Scope

- Reject self-parenting and ancestor cycles during model validation and normal saves.
- Require every parent and ancestor to be a folder owned by the same user.
- Prevent an established parent folder from becoming a feed or changing owners while it has children.
- Make unread counting, unread-post collection, pagination source collection, `mark_read()`, and unread-root reduction terminate when legacy or externally written rows contain cycles or invalid parents.
- Preserve Django save semantics for routed databases, positional `using`, and one-shot `update_fields` iterables.
- Update the current-state specification and add regression coverage for every hierarchy invariant and defensive traversal path.

## Non-goals

- No schema or data migration is introduced.
- Existing malformed rows are not detached or rewritten.
- Bulk updates, raw SQL, and other validation-bypassing writes are not prohibited; runtime traversal remains defensive for those cases.
- Public utility signatures, model fields, and related names are unchanged.

## Acceptance criteria

- [x] Self-parenting and ancestor cycles are rejected.
- [x] A parent must be a folder subscription belonging to the same user.
- [x] Traversal methods terminate safely when malformed legacy data exists.
- [x] Tests cover self-cycles, multi-node cycles, cross-user parents, non-folder parents, valid nested trees, and reverse mutations of an established parent.

## Implementation notes

- `Subscription.clean()` and `Subscription.save()` share hierarchy validation, while partial saves unrelated to hierarchy fields avoid unnecessary validation.
- Ancestor validation uses the actual write database and visited identifiers for cycle detection.
- `update_fields` is normalized once before validation and delegation to Django.
- Descendant traversal is iterative and yields each subscription at most once.
- Unread-folder reduction tolerates missing parents and exits when malformed cycles prevent further reduction.

## Validation

- Independent issue verification: all acceptance criteria verified.
- `mad-skills check --full`: `READY WITH WARNINGS`.
- Project tests: `133 passed, 3 skipped`.
- Focused subscription tests: `22 passed`.
- `git diff --check`: passed.
- Migration check: no changes detected.

The remaining readiness warning is an unrelated unlinked Claude skill; the Codex workflow and project checks are ready.

## Data and security considerations

Same-user validation closes the model-save cross-user hierarchy boundary. Existing malformed data remains in place but cannot cause the covered traversals to loop indefinitely. Because no persisted structure changes, rollout requires no migration or data rewrite.

## Known risks

Model validation can still be bypassed by bulk or external database writes. Defensive, user-scoped traversal limits the impact of such legacy or externally introduced rows.
