### PR TITLE
Fix: treat HTTP 429 as retryable instead of permanently disabling the source

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 
 ### 2.0.1
+- Fix: HTTP 429 (rate limited) responses no longer permanently disable a source; polling now backs off and honors a valid `Retry-After` header (seconds or HTTP-date), bounded by the existing min/max poll interval
 - Security: Validate DNS results and every hop in bounded manual redirect chains before connecting
 - Fix: Bound first-import XML/Atom pagination, detect repeated page URLs, and stop cleanly on failed pagination responses
 - Fix: `get_unread_subscription_list_for_user` no longer returns read-only folder subscriptions as unread

--- a/feeds/tests/test_http.py
+++ b/feeds/tests/test_http.py
@@ -148,7 +148,7 @@ class HTTPStuffTest(BaseTest):
         self.assertEqual(src.status_code, 401)
         self.assertFalse(src.live)
 
-    def test_http_429_disables_feed(self, mock):
+    def test_http_429_keeps_feed_live(self, mock):
 
         self._populate_mock(
             mock, status=429, test_file="empty_file.txt", content_type="text/plain"
@@ -161,7 +161,98 @@ class HTTPStuffTest(BaseTest):
         src.refresh_from_db()
 
         self.assertEqual(src.status_code, 429)
-        self.assertFalse(src.live)
+        self.assertTrue(src.live)
+        self.assertIn("Rate limited", src.last_result)
+        # No Retry-After header, so it falls back to the default bounded backoff.
+        self.assertEqual(src.interval, 120)
+        self.assertGreater(src.due_poll, timezone.now())
+
+    def test_http_429_honors_retry_after_seconds(self, mock):
+
+        self._populate_mock(
+            mock,
+            status=429,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Retry-After": "5400"},  # 90 minutes
+        )
+
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        before = timezone.now()
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.status_code, 429)
+        self.assertTrue(src.live)
+        self.assertEqual(src.interval, 90)
+        self.assertGreaterEqual(
+            src.due_poll, before + timedelta(minutes=90) - timedelta(seconds=5)
+        )
+
+    def test_http_429_honors_retry_after_http_date(self, mock):
+
+        retry_at = timezone.now() + timedelta(minutes=90)
+
+        self._populate_mock(
+            mock,
+            status=429,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Retry-After": retry_at.strftime("%a, %d %b %Y %H:%M:%S GMT")},
+        )
+
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.status_code, 429)
+        self.assertTrue(src.live)
+        self.assertEqual(src.interval, 90)
+
+    def test_http_429_bounds_excessive_retry_after(self, mock):
+
+        self._populate_mock(
+            mock,
+            status=429,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Retry-After": str(60 * 60 * 24 * 30)},  # 30 days
+        )
+
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.status_code, 429)
+        self.assertTrue(src.live)
+        # The maximum poll interval (24h) still applies.
+        self.assertEqual(src.interval, 60 * 24)
+
+    def test_http_429_ignores_invalid_retry_after(self, mock):
+
+        self._populate_mock(
+            mock,
+            status=429,
+            test_file="empty_file.txt",
+            content_type="text/plain",
+            headers={"Retry-After": "not-a-valid-value"},
+        )
+
+        src = Source(name="test1", feed_url=BASE_URL, interval=0)
+        src.save()
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.status_code, 429)
+        self.assertTrue(src.live)
+        self.assertEqual(src.interval, 120)
 
     def test_not_a_feed(self, mock):
 

--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -18,6 +18,7 @@ from feeds.utils_internal import (
     VERIFY_HTTPS,
     get_agent,
     parse_feed,
+    parse_retry_after_minutes,
 )
 
 DRIPFEED_KEY = None
@@ -238,6 +239,16 @@ def _read_feed_process_http_response(
             source_feed.last_result = "Feed is no longer accessible."
             source_feed.live = False
 
+    elif ret.status_code == 429:
+        retry_minutes = parse_retry_after_minutes(ret.headers.get("Retry-After"))
+        if retry_minutes is not None:
+            source_feed.interval = max(source_feed.interval, retry_minutes)
+            source_feed.last_result = (
+                "Rate limited (429), retrying in %d minute(s)" % retry_minutes
+            )
+        else:
+            source_feed.interval += 120
+            source_feed.last_result = "Rate limited (429)"
     elif ret.status_code >= 400 and ret.status_code < 500:
         source_feed.live = False
         source_feed.last_result = "Bad request (%d)" % ret.status_code

--- a/feeds/utils_internal.py
+++ b/feeds/utils_internal.py
@@ -2,8 +2,10 @@ import datetime
 import hashlib
 import json
 import logging
+import math
 import time
-from typing import TextIO
+from email.utils import parsedate_to_datetime
+from typing import Optional, TextIO
 
 import feedparser as parser
 import pyrfc3339
@@ -52,6 +54,46 @@ def _positive_int_setting(name: str, default: int) -> int:
 def _pagination_limit(name: str, value: int) -> str:
     unit = name[:-1] if value == 1 else name
     return f"Pagination stopped at {value} {unit}"
+
+
+def parse_retry_after_minutes(value: Optional[str]) -> Optional[int]:
+    """Parse a ``Retry-After`` header value into whole minutes to wait.
+
+    Accepts either the delay-seconds form (an integer) or the HTTP-date
+    form. Returns ``None`` if ``value`` is missing or cannot be parsed as
+    either form.
+    """
+    if not value:
+        return None
+
+    value = value.strip()
+
+    try:
+        seconds = int(value)
+    except ValueError:
+        seconds = None
+
+    if seconds is not None:
+        if seconds < 0:
+            return None
+        return max(1, math.ceil(seconds / 60))
+
+    try:
+        retry_date = parsedate_to_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+    if retry_date is None:
+        return None
+
+    if retry_date.tzinfo is None:
+        retry_date = retry_date.replace(tzinfo=datetime.timezone.utc)
+
+    delta_seconds = (retry_date - timezone.now()).total_seconds()
+    if delta_seconds <= 0:
+        return 1
+
+    return max(1, math.ceil(delta_seconds / 60))
 
 
 def _next_feed_page(feed, current_url: str):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #49.

HTTP 429 (rate limited) responses fell into the generic 4xx branch in `_read_feed_process_http_response`, which set `Source.live = False`. A temporary rate limit therefore permanently unsubscribed the source from polling, requiring manual reactivation.

## Fix

- Added a dedicated `429` branch in `feeds/utils.py` that leaves `Source.live` untouched (source stays live) and applies a bounded retry delay:
  - If the response includes a valid `Retry-After` header (delay-seconds form or HTTP-date form), that value is honored — converted to whole minutes and used to raise `Source.interval` (subject to the existing 60 minute / 24 hour poll interval clamp applied for all sources in `_read_feed_finalize_interval_and_save`).
  - Otherwise, a default backoff (`interval += 120`) is applied, matching the pattern used for other transient errors (e.g. 5xx, 404).
- Added `parse_retry_after_minutes` to `feeds/utils_internal.py` to parse `Retry-After` values (seconds or HTTP-date), returning `None` for missing/invalid values.

## Tests

Replaced the old `test_http_429_disables_feed` regression test (which asserted the buggy permanent-disable behavior) with:

- `test_http_429_keeps_feed_live` — source stays live with default backoff when no `Retry-After` header is present.
- `test_http_429_honors_retry_after_seconds` — a `Retry-After: <seconds>` header sets the poll interval accordingly.
- `test_http_429_honors_retry_after_http_date` — a `Retry-After: <HTTP-date>` header is parsed and honored.
- `test_http_429_bounds_excessive_retry_after` — an excessively long `Retry-After` is bounded by the existing max poll interval (24h).
- `test_http_429_ignores_invalid_retry_after` — an unparsable `Retry-After` value falls back to the default backoff.

Other 4xx handling (401, 403, 404, 410, generic 4xx) is unchanged.

Full test suite (`pytest --reuse-db`) passes: 137 passed, 3 skipped (pre-existing, unrelated).

## Changelog

Added an entry under the unreleased `2.0.1` section.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f2c5e0a-c3cc-44a4-b291-3847d4d05e3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f2c5e0a-c3cc-44a4-b291-3847d4d05e3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

