### PR TITLE
Fix stale num_subs when subscription changes source

### DIFF
--- a/feeds/models.py
+++ b/feeds/models.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
 from django.db import models, router
 from django.db.models import Q
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 from django.utils.deconstruct import deconstructible
 
@@ -705,6 +705,17 @@ def _subscription_children_by_parent(user_id):
     return by_parent
 
 
+@receiver(pre_save)
+def pre_save_subscriber(sender, instance, **kwargs):
+    if sender == Subscription and instance.pk is not None:
+        try:
+            instance._previous_source = Subscription.objects.get(pk=instance.pk).source
+        except Subscription.DoesNotExist:
+            instance._previous_source = None
+    elif sender == Subscription:
+        instance._previous_source = None
+
+
 @receiver(post_delete)
 def delete_subscriber(sender, instance, **kwargs):
     if sender == Subscription and instance.source is not None:
@@ -713,5 +724,11 @@ def delete_subscriber(sender, instance, **kwargs):
 
 @receiver(post_save)
 def save_subscriber(sender, instance, **kwargs):
-    if sender == Subscription and instance.source is not None:
-        instance.source.update_subscriber_count()
+    if sender != Subscription:
+        return
+    previous_source = getattr(instance, '_previous_source', None)
+    current_source = instance.source
+    if current_source is not None:
+        current_source.update_subscriber_count()
+    if previous_source is not None and previous_source != current_source:
+        previous_source.update_subscriber_count()

--- a/feeds/tests/test_subscriptions.py
+++ b/feeds/tests/test_subscriptions.py
@@ -776,3 +776,76 @@ class SubscriptionSaveCompatibilityTest(BaseTest):
 
         subscription.refresh_from_db()
         self.assertEqual(subscription.name, "After")
+
+
+class SubscriberCountTest(BaseTest):
+    """Regression tests for num_subs recalculation when subscriptions change source."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user("countuser", "c@example.com", "pass")
+        self.source_a = Source.objects.create(
+            name="Source A", feed_url="http://a.example.com/feed"
+        )
+        self.source_b = Source.objects.create(
+            name="Source B", feed_url="http://b.example.com/feed"
+        )
+
+    def test_move_subscription_updates_both_sources(self):
+        user2 = User.objects.create_user("countuser2", "c2@example.com", "pass")
+        Subscription.objects.create(user=self.user, source=self.source_a)
+        sub2 = Subscription.objects.create(user=user2, source=self.source_a)
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 2)
+
+        sub2.source = self.source_b
+        sub2.save()
+
+        self.source_a.refresh_from_db()
+        self.source_b.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 1)
+        self.assertEqual(self.source_b.num_subs, 1)
+
+    def test_clear_source_updates_old_source(self):
+        sub = Subscription.objects.create(user=self.user, source=self.source_a)
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 1)
+
+        sub.source = None
+        sub.save()
+
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 0)
+
+    def test_assign_source_updates_new_source(self):
+        sub = Subscription.objects.create(user=self.user, source=None, name="folder")
+        self.source_a.refresh_from_db()
+        # No subscriptions point to source_a yet (default num_subs=1, but
+        # the signal hasn't touched it since no sub references it).
+        # After assigning, count should reflect the new subscription.
+
+        sub.source = self.source_a
+        sub.save()
+
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 1)
+
+    def test_save_without_change_is_idempotent(self):
+        sub = Subscription.objects.create(user=self.user, source=self.source_a)
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 1)
+
+        sub.save()
+
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 1)
+
+    def test_delete_updates_source(self):
+        sub = Subscription.objects.create(user=self.user, source=self.source_a)
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 1)
+
+        sub.delete()
+
+        self.source_a.refresh_from_db()
+        self.assertEqual(self.source_a.num_subs, 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #50

## Problem

When a `Subscription.source` was changed (e.g. moved from source A to source B), only the **new** source's `num_subs` was recalculated. The **old** source retained a stale count because the `post_save` signal only had access to the current `instance.source`.

## Solution

Added a `pre_save` signal that captures the previous source before the save occurs. The `post_save` signal now recalculates `num_subs` for both the old and new sources when they differ.

This correctly handles:
- Moving a subscription from one source to another
- Clearing a subscription's source (turning it into a folder)
- Assigning a source to a previously source-less subscription
- Ordinary saves where the source hasn't changed (idempotent)
- Deleting a subscription (existing `post_delete` handler, unchanged)

## Tests

Added `SubscriberCountTest` class with 5 regression tests covering all the above cases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf8d9a70-4629-4fca-baf9-e18ad40aa1be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf8d9a70-4629-4fca-baf9-e18ad40aa1be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

