### PR TITLE
fix: accept XML feeds with declared non-UTF-8 encodings

### DIFF
--- a/feeds/tests/test_http.py
+++ b/feeds/tests/test_http.py
@@ -627,6 +627,20 @@ class HTTPStuffTest(BaseTest):
         self.assertEqual(src.last_result, "Feed body is not valid UTF-8")
         self.assertEqual(src.posts.count(), 0)
 
+    def test_invalid_utf8_json_detected_by_first_byte(self, mock):
+        mock.get(
+            BASE_URL,
+            content=b'{"title":"\xff"}',
+            headers={"Content-Type": "text/plain"},
+        )
+        src = Source.objects.create(name="test", feed_url=BASE_URL, interval=0)
+
+        read_feed(src, output=NullOutput())
+        src.refresh_from_db()
+
+        self.assertEqual(src.last_result, "Feed body is not valid UTF-8")
+        self.assertEqual(src.posts.count(), 0)
+
     def test_temp_redirect_relative_location(self, mock):
 
         resolved = "http://feed.com/second.xml"

--- a/feeds/tests/test_xml_feeds.py
+++ b/feeds/tests/test_xml_feeds.py
@@ -1,5 +1,6 @@
 import os
 from importlib import reload
+from unittest.mock import patch
 
 import requests_mock
 from django.conf import settings
@@ -42,6 +43,29 @@ def _atom_feed(entry_ids, next_url=None):
 
 @requests_mock.Mocker()
 class XMLFeedsTest(BaseTest):
+    def test_declared_latin1_xml_reaches_feedparser_unchanged(self, mock):
+        body = '''<?xml version="1.0" encoding="ISO-8859-1"?>
+        <rss version="2.0"><channel><title>Café feed</title>
+        <link>http://feed.com/</link><description>News</description>
+        <item><title>Crème brûlée</title><guid>latin1-entry</guid>
+        <link>http://feed.com/entry</link><description>Déjà vu</description>
+        </item></channel></rss>'''.encode("iso-8859-1")
+        for index, content_type in enumerate(("application/rss+xml", "text/plain")):
+            with self.subTest(content_type=content_type):
+                url = BASE_URL + str(index)
+                mock.get(url, content=body, headers={"Content-Type": content_type})
+                src = Source.objects.create(name="test", feed_url=url, interval=0)
+                with patch.object(
+                    utils_internal.parser, "parse", wraps=utils_internal.parser.parse
+                ) as parse:
+                    read_feed(src, output=NullOutput())
+                src.refresh_from_db()
+                self.assertEqual(src.name, "Café feed")
+                self.assertEqual(src.posts.get().title, "Crème brûlée")
+                self.assertEqual(src.posts.get().body, "Déjà vu")
+                self.assertEqual(parse.call_args.args[0], body)
+                self.assertIsInstance(parse.call_args.args[0], bytes)
+
     def test_atom_follows_rel_next_on_first_parse(self, mock):
         """First full parse should follow atom:link[@rel='next'] and merge pages."""
 

--- a/feeds/utils_internal.py
+++ b/feeds/utils_internal.py
@@ -363,19 +363,20 @@ def parse_feed(source_feed: Source, feed_body, content_type, output: TextIO):
         source_feed.last_result = "Empty feed response"
         return (False, False)
 
-    try:
-        feed_text_for_json = feed_body.decode("utf-8")
-    except UnicodeDecodeError:
-        source_feed.last_result = "Feed body is not valid UTF-8"
-        return (False, False)
-
     if "xml" in content_type or feed_body[0:1] == b"<":
         (ok, changed) = parse_feed_xml(source_feed, feed_body, output)
-    elif "json" in content_type or feed_body[0:1] == b"{":
-        (ok, changed) = parse_feed_json(source_feed, feed_text_for_json, output)
     else:
-        ok = False
-        source_feed.last_result = "Unknown Feed Type: " + content_type
+        try:
+            feed_text_for_json = feed_body.decode("utf-8")
+        except UnicodeDecodeError:
+            source_feed.last_result = "Feed body is not valid UTF-8"
+            return (False, False)
+
+        if "json" in content_type or feed_body[0:1] == b"{":
+            (ok, changed) = parse_feed_json(source_feed, feed_text_for_json, output)
+        else:
+            ok = False
+            source_feed.last_result = "Unknown Feed Type: " + content_type
 
     if ok and changed:
         source_feed.last_result = " OK (updated)"  # and temporary redirects


### PR DESCRIPTION
Valid RSS/Atom feeds declaring legacy encodings were rejected by an unconditional UTF-8 decode before XML parsing. Select XML using the existing content-type/first-byte rule first, then pass unchanged response bytes to feedparser. The non-XML path retains UTF-8 validation, JSON dispatch and unknown-type errors.

Regression coverage exercises ISO-8859-1 RSS through both existing XML detection paths, checks stored accented titles/body and verifies unchanged bytes at feedparser's boundary. Invalid JSON bytes are rejected with zero stored posts both with application/json and when selected by their first byte under text/plain. Public APIs, models, settings, schema, detection precedence and whitespace/BOM handling are preserved.

Validation at 44b9e5e6e7883275955a9fa33d0b822e88b592e5: Python 3.12 / Django 4.2, 144 passed and 3 MySQL-only tests skipped; mad-skills check --full passed with existing Claude skill-link warnings; git diff --check passed. The XML regression fails against the original dispatch and passes after the fix.

Supervised trial evidence: the initial commit passed independent acceptance verification and fresh high-effort review. The disclosed first-byte JSON regression was completed in remediation commit 44b9e5e. Renewed [independent verification](https://github.com/xurble/django-feed-reader/pull/62#issuecomment-5583954256) passed all criteria and remediation at the final head. A new [fresh high-effort review](https://github.com/xurble/django-feed-reader/pull/62#pullrequestreview-5140755305) found no significant issues; independent tests returned 144 passed / 3 MySQL-only skips, the full check passed with the existing three Claude skill-link warnings, and all nine current CI checks succeeded. The clean-readiness gates are complete. No merge or issue closure is authorized.

Refs #51

